### PR TITLE
Rewrite "Extract Variable"

### DIFF
--- a/src/ast/domain.ts
+++ b/src/ast/domain.ts
@@ -1,3 +1,4 @@
+import { NodePath } from "@babel/traverse";
 import * as t from "@babel/types";
 
 export * from "@babel/types";
@@ -6,11 +7,12 @@ export {
   areAllObjectProperties,
   isUndefinedLiteral,
   isTemplateExpression,
+  isFunctionCallIdentifier,
+  isClassPropertyIdentifier,
+  isVariableDeclarationIdentifier,
   templateElement,
   Primitive
 };
-
-// === AST DOMAIN ===
 
 function isArrayExpressionElement(
   node: t.Node | null
@@ -40,6 +42,22 @@ function isTemplateExpression(node: t.Node): node is TemplateExpression {
 }
 
 type TemplateExpression = t.Identifier | t.CallExpression | t.MemberExpression;
+
+function isFunctionCallIdentifier(path: NodePath): boolean {
+  return t.isCallExpression(path.parent) && path.parent.callee === path.node;
+}
+
+function isClassPropertyIdentifier(path: NodePath): boolean {
+  return (
+    t.isClassProperty(path.parent) &&
+    !path.parent.computed &&
+    t.isIdentifier(path.node)
+  );
+}
+
+function isVariableDeclarationIdentifier(path: NodePath): boolean {
+  return t.isVariableDeclarator(path.parent) && t.isIdentifier(path.node);
+}
 
 /**
  * Override babel `templateElement()` because it exposes

--- a/src/refactorings/extract-variable/command.ts
+++ b/src/refactorings/extract-variable/command.ts
@@ -31,8 +31,8 @@ async function extractVariableCommand() {
       document.getText(),
       createSelectionFromVSCode(selection),
       createReadThenWriteInVSCode(document),
-      delegateToVSCode,
-      showErrorMessageInVSCode
+      showErrorMessageInVSCode,
+      delegateToVSCode
     )
   );
 }

--- a/src/refactorings/extract-variable/command.ts
+++ b/src/refactorings/extract-variable/command.ts
@@ -6,7 +6,7 @@ import { extractVariable } from "./extract-variable";
 import { delegateToVSCode } from "../../editor/adapters/delegate-to-vscode";
 import { showErrorMessageInVSCode } from "../../editor/adapters/show-error-message-in-vscode";
 import {
-  createReadThenWriteInVSCode,
+  createWriteInVSCode,
   createSelectionFromVSCode
 } from "../../editor/adapters/write-code-in-vscode";
 
@@ -30,7 +30,7 @@ async function extractVariableCommand() {
     extractVariable(
       document.getText(),
       createSelectionFromVSCode(selection),
-      createReadThenWriteInVSCode(document),
+      createWriteInVSCode(activeTextEditor),
       showErrorMessageInVSCode,
       delegateToVSCode
     )

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -95,40 +95,35 @@ console.log(extracted);`);
         code: `console.log("Hello!");`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = "Hello!";
-console.log(extracted);`,
-        skip: true
+console.log(extracted);`
       },
       {
         description: "a number",
         code: `console.log(12.5);`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = 12.5;
-console.log(extracted);`,
-        skip: true
+console.log(extracted);`
       },
       {
         description: "a boolean",
         code: `console.log(false);`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = false;
-console.log(extracted);`,
-        skip: true
+console.log(extracted);`
       },
       {
         description: "null",
         code: `console.log(null);`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = null;
-console.log(extracted);`,
-        skip: true
+console.log(extracted);`
       },
       {
         description: "undefined",
         code: `console.log(undefined);`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = undefined;
-console.log(extracted);`,
-        skip: true
+console.log(extracted);`
       },
       {
         description: "an array",

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -387,8 +387,7 @@ console.log(extracted.name);`
         expected: `function getMessage() {
   const extracted = "Hello!";
   return extracted;
-}`,
-        skip: true
+}`
       },
       {
         description: "an assigned variable",

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -808,8 +808,8 @@ const sayHello = extracted;`
       code,
       selection,
       readThenWrite,
-      delegateToEditor,
-      showErrorMessage
+      showErrorMessage,
+      delegateToEditor
     );
     return getCode();
   }

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -430,16 +430,14 @@ console.log(extracted);`
         code: "if (parents.length > 0 && type === 'refactor') doSomething();",
         selection: new Selection([0, 4], [0, 45]),
         expected: `const extracted = parents.length > 0 && type === 'refactor';
-if (extracted) doSomething();`,
-        skip: true
+if (extracted) doSomething();`
       },
       {
         description: "an if statement (part of it)",
         code: "if (parents.length > 0 && type === 'refactor') doSomething();",
         selection: new Selection([0, 4], [0, 22]),
         expected: `const extracted = parents.length > 0;
-if (extracted && type === 'refactor') doSomething();`,
-        skip: true
+if (extracted && type === 'refactor') doSomething();`
       },
       {
         description: "a multi-lines if statement (whole statement)",
@@ -448,12 +446,10 @@ if (extracted && type === 'refactor') doSomething();`,
   type === 'refactor'
 ) doSomething();`,
         selection: new Selection([1, 2], [2, 21]),
-        expected: `const extracted = parents.length > 0 &&
-  type === 'refactor';
+        expected: `const extracted = parents.length > 0 && type === 'refactor';
 if (
   extracted
-) doSomething();`,
-        skip: true
+) doSomething();`
       },
       {
         description: "a multi-lines if statement (part of it)",
@@ -466,8 +462,7 @@ if (
 if (
   parents.length > 0 &&
   extracted
-) doSomething();`,
-        skip: true
+) doSomething();`
       },
       {
         description: "a while statement",
@@ -475,8 +470,7 @@ if (
           "while (parents.length > 0 && type === 'refactor') doSomething();",
         selection: new Selection([0, 7], [0, 48]),
         expected: `const extracted = parents.length > 0 && type === 'refactor';
-while (extracted) doSomething();`,
-        skip: true
+while (extracted) doSomething();`
       },
       {
         description: "a case statement",
@@ -491,8 +485,7 @@ switch (text) {
   case extracted:
   default:
     break;
-}`,
-        skip: true
+}`
       },
       {
         description: "an unamed function parameter when cursor is inside",

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -648,8 +648,7 @@ if (
         code: `console.log(new Error("It failed"));`,
         selection: Selection.cursorAt(0, 14),
         expected: `const extracted = new Error("It failed");
-console.log(extracted);`,
-        skip: true
+console.log(extracted);`
       },
       {
         description: "a call expression parameter (multi-lines)",
@@ -664,8 +663,7 @@ createIfStatement(
   extracted,
   parentPath.node.left,
   node.consequent
-);`,
-        skip: true
+);`
       },
       {
         description: "a conditional expression (multi-lines)",
@@ -704,8 +702,7 @@ const type = !!(
         expected: `const extracted = "name";
 new Author(
   extracted
-);`,
-        skip: true
+);`
       },
       {
         description: "a value in an Array argument of a function",
@@ -727,8 +724,7 @@ doSomething([
         expected: `const extracted = new Author("Eliott");
 doSomething([
   extracted
-]);`,
-        skip: true
+]);`
       },
       {
         description: "a value in a binary expression",

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -335,8 +335,8 @@ const a = { [key]: extracted };`
     return "bar";
   }
 };
-console.log(extracted);`,
-        skip: true
+
+console.log(extracted);`
       },
       {
         description:
@@ -350,9 +350,11 @@ console.log({ foo: extracted });`
         description: "a spread variable",
         code: `console.log({ ...foo.bar });`,
         selection: Selection.cursorAt(0, 22),
-        expected: `const extracted = { ...foo.bar };
-console.log(extracted);`,
-        skip: true
+        expected: `const extracted = {
+  ...foo.bar
+};
+
+console.log(extracted);`
       },
       {
         description: "a spread function result",
@@ -365,8 +367,8 @@ console.log(extracted);`,
   ...getInlinableCode(declaration),
   id: "name"
 };
-console.log(extracted);`,
-        skip: true
+
+console.log(extracted);`
       },
       {
         description:
@@ -374,8 +376,7 @@ console.log(extracted);`,
         code: `console.log(path.node.name);`,
         selection: Selection.cursorAt(0, 17),
         expected: `const extracted = path.node;
-console.log(extracted.name);`,
-        skip: true
+console.log(extracted.name);`
       },
       {
         description: "a return value of a function",

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -678,8 +678,7 @@ createIfStatement(
 const type = !!(
   extracted > 0
 ) ? "with-loc"
-  : "without-loc";`,
-        skip: true
+  : "without-loc";`
       },
       {
         description: "a value in a JSXExpressionContainer",
@@ -694,8 +693,7 @@ const type = !!(
   text={getTextForPerson({
     name: extracted
   })}
-/>`,
-        skip: true
+/>`
       },
       {
         description: "a value in a new Expression",
@@ -718,8 +716,7 @@ new Author(
         expected: `const extracted = getValueOf("name");
 doSomething([
   extracted
-]);`,
-        skip: true
+]);`
       },
       {
         description: "a new Expression in an Array argument of a function",
@@ -744,8 +741,7 @@ doSomething([
 console.log(
   currentValue >
   extracted
-);`,
-        skip: true
+);`
       },
       {
         description: "an arrow function (cursor on params)",
@@ -784,7 +780,7 @@ const sayHello = extracted;`,
 }`);
   });
 
-  it.skip("should not wrap extracted JSX element inside JSX Expression Container when not inside another", async () => {
+  it("should not wrap extracted JSX element inside JSX Expression Container when not inside another", async () => {
     const code = `function render() {
   return <p>{name}</p>;
 }`;

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -493,11 +493,11 @@ switch (text) {
   return "Hello!";
 });`,
         selection: Selection.cursorAt(1, 0),
-        expected: `const extracted = function () {
+        expected: `const extracted = function() {
   return "Hello!";
 };
-console.log(extracted);`,
-        skip: true
+
+console.log(extracted);`
       },
       {
         description: "an exported variable declaration",
@@ -508,8 +508,7 @@ console.log(extracted);`,
         expected: `const extracted = "bar";
 export const something = {
   foo: extracted
-};`,
-        skip: true
+};`
       },
       {
         description: "an object returned from arrow function",
@@ -520,8 +519,7 @@ export const something = {
         expected: `const extracted = "bar";
 const something = () => ({
   foo: extracted
-});`,
-        skip: true
+});`
       },
       {
         description: "a value inside an arrow function",
@@ -532,8 +530,7 @@ const something = () => ({
         expected: `const extracted = "Hello";
 () => (
   console.log(extracted)
-)`,
-        skip: true
+)`
       },
       {
         description: "an object from a nested call expression",
@@ -541,11 +538,13 @@ const something = () => ({
   getError({ context: ["value"] })
 );`,
         selection: Selection.cursorAt(1, 15),
-        expected: `const extracted = { context: ["value"] };
+        expected: `const extracted = {
+  context: ["value"]
+};
+
 assert.isTrue(
   getError(extracted)
-);`,
-        skip: true
+);`
       },
       {
         description: "a multi-lines ternary",
@@ -560,8 +559,7 @@ assert.isTrue(
   return isValid
     ? extracted
     : "no";
-}`,
-        skip: true
+}`
       },
       {
         description: "a multi-lines unary expression",
@@ -576,8 +574,7 @@ if (
   !(threshold > extracted || isPaused)
 ) {
   console.log("Ship it");
-}`,
-        skip: true
+}`
       },
       {
         description: "a variable in a JSX element",

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -405,8 +405,7 @@ const message = extracted;`
         expected: `const extracted = "Hello!";
 class Logger {
   message = extracted;
-}`,
-        skip: true
+}`
       },
       {
         description: "a computed class property",
@@ -417,8 +416,7 @@ class Logger {
         expected: `const extracted = key;
 class Logger {
   [extracted] = "value";
-}`,
-        skip: true
+}`
       },
       {
         description: "an interpolated string when cursor is on a subpart of it",

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -745,11 +745,11 @@ console.log(
   console.log(name);
 };`,
         selection: Selection.cursorAt(0, 20),
-        expected: `const extracted = (name) => {
+        expected: `const extracted = name => {
   console.log(name);
 };
-const sayHello = extracted;`,
-        skip: true
+
+const sayHello = extracted;`
       }
     ],
     async ({ code, selection, expected }) => {
@@ -758,7 +758,7 @@ const sayHello = extracted;`,
     }
   );
 
-  it.skip("should wrap extracted JSX element inside JSX Expression Container when inside another", async () => {
+  it("should wrap extracted JSX element inside JSX Expression Container when inside another", async () => {
     const code = `function render() {
   return <div className="text-lg font-weight-bold">
     <p>{name}</p>
@@ -770,9 +770,11 @@ const sayHello = extracted;`,
 
     expect(result).toBe(`function render() {
   const extracted = <p>{name}</p>;
-  return <div className="text-lg font-weight-bold">
-    {extracted}
-  </div>
+  return (
+    <div className="text-lg font-weight-bold">
+      {extracted}
+    </div>
+  );
 }`);
   });
 
@@ -812,8 +814,7 @@ const sayHello = extracted;`,
       {
         description: "the identifier from a variable declaration",
         code: `const foo = "bar";`,
-        selection: new Selection([0, 6], [0, 9]),
-        skip: true
+        selection: new Selection([0, 6], [0, 9])
       }
     ],
     async ({ code, selection }) => {

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -423,8 +423,7 @@ class Logger {
         code: "console.log(`Hello ${world}! How are you doing?`);",
         selection: Selection.cursorAt(0, 15),
         expected: `const extracted = \`Hello \${world}! How are you doing?\`;
-console.log(extracted);`,
-        skip: true
+console.log(extracted);`
       },
       {
         description: "an if statement (whole statement)",

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -147,9 +147,13 @@ console.log(extracted);`
         description: "an object",
         code: `console.log({ one: 1, foo: true, hello: 'World!' });`,
         selection: Selection.cursorAt(0, 12),
-        expected: `const extracted = { one: 1, foo: true, hello: 'World!' };
-console.log(extracted);`,
-        skip: true
+        expected: `const extracted = {
+  one: 1,
+  foo: true,
+  hello: 'World!'
+};
+
+console.log(extracted);`
       },
       {
         description: "an object (multi-lines)",
@@ -164,8 +168,8 @@ console.log(extracted);`,
   foo: true,
   hello: 'World!'
 };
-console.log(extracted);`,
-        skip: true
+
+console.log(extracted);`
       },
       {
         description: "a named function",
@@ -176,24 +180,22 @@ console.log(extracted);`,
         expected: `const extracted = function sayHello() {
   return "Hello!";
 };
-console.log(extracted);`,
-        skip: true
+
+console.log(extracted);`
       },
       {
         description: "an arrow function",
         code: `console.log(() => "Hello!");`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = () => "Hello!";
-console.log(extracted);`,
-        skip: true
+console.log(extracted);`
       },
       {
         description: "a function call",
         code: `console.log(sayHello("World"));`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = sayHello("World");
-console.log(extracted);`,
-        skip: true
+console.log(extracted);`
       },
       {
         description: "the correct variable when we have many",
@@ -204,8 +206,7 @@ console.log("How are you doing?");`,
         expected: `console.log("Hello");
 const extracted = "World!";
 console.log("the", extracted, "Alright.");
-console.log("How are you doing?");`,
-        skip: true
+console.log("How are you doing?");`
       },
       {
         description: "a multi-lines object when cursor is inside",
@@ -220,8 +221,8 @@ console.log("How are you doing?");`,
   foo: true,
   hello: 'World!'
 };
-console.log(extracted);`,
-        skip: true
+
+console.log(extracted);`
       },
       {
         description: "an element nested in a multi-lines object",
@@ -238,8 +239,7 @@ console.log({
   foo: {
     bar: extracted
   }
-});`,
-        skip: true
+});`
       },
       {
         description:
@@ -257,8 +257,7 @@ const a = {
   foo: {
     bar: extracted
   }
-};`,
-        skip: true
+};`
       },
       {
         description: "an element in a multi-lines array",
@@ -275,8 +274,7 @@ const SUPPORTED_LANGUAGES = [
   extracted,
   "typescript",
   "typescriptreact"
-];`,
-        skip: true
+];`
       },
       {
         description: "an element nested in a multi-lines array",
@@ -297,32 +295,32 @@ console.log([
       hello: extracted
     }
   ]
-]);`,
-        skip: true
+]);`
       },
       {
         description: "the whole object when cursor is on its property",
         code: `console.log({ foo: "bar", one: true });`,
         selection: Selection.cursorAt(0, 16),
-        expected: `const extracted = { foo: "bar", one: true };
-console.log(extracted);`,
-        skip: true
+        expected: `const extracted = {
+  foo: "bar",
+  one: true
+};
+
+console.log(extracted);`
       },
       {
         description: "a computed object property",
         code: `const a = { [key]: "value" };`,
         selection: Selection.cursorAt(0, 13),
         expected: `const extracted = key;
-const a = { [extracted]: "value" };`,
-        skip: true
+const a = { [extracted]: "value" };`
       },
       {
         description: "a computed object property value when cursor is on value",
         code: `const a = { [key]: "value" };`,
         selection: Selection.cursorAt(0, 19),
         expected: `const extracted = "value";
-const a = { [key]: extracted };`,
-        skip: true
+const a = { [key]: extracted };`
       },
       {
         description: "the whole object when cursor is on a method declaration",
@@ -346,8 +344,7 @@ console.log(extracted);`,
         code: `console.log({ foo: { bar: true } });`,
         selection: Selection.cursorAt(0, 21),
         expected: `const extracted = { bar: true };
-console.log({ foo: extracted });`,
-        skip: true
+console.log({ foo: extracted });`
       },
       {
         description: "a spread variable",
@@ -397,8 +394,7 @@ console.log(extracted.name);`,
         code: `const message = "Hello!";`,
         selection: Selection.cursorAt(0, 16),
         expected: `const extracted = "Hello!";
-const message = extracted;`,
-        skip: true
+const message = extracted;`
       },
       {
         description: "a class property assignment",
@@ -823,16 +819,14 @@ const sayHello = extracted;`,
         code: `function sayHello() {
   console.log("hello");
 }`,
-        selection: new Selection([0, 0], [2, 1]),
-        skip: true
+        selection: new Selection([0, 0], [2, 1])
       },
       {
         description: "a class property identifier",
         code: `class Logger {
   message = "Hello!";
 }`,
-        selection: new Selection([1, 2], [1, 9]),
-        skip: true
+        selection: new Selection([1, 2], [1, 9])
       },
       {
         description: "the identifier from a variable declaration",

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -587,11 +587,12 @@ if (
         // Note: maybe we'd like to improve this one (double `{}`)
         expected: `function render() {
   const extracted = this.props.location.name;
-  return <div className="text-lg font-weight-bold">
-    {extracted}
-  </div>;
-}`,
-        skip: true
+  return (
+    <div className="text-lg font-weight-bold">
+      {extracted}
+    </div>
+  );
+}`
       },
       {
         description: "a JSX element (cursor on opening tag)",
@@ -605,9 +606,9 @@ if (
   const extracted = <div className="text-lg font-weight-bold">
     {this.props.location.name}
   </div>;
+
   return extracted;
-}`,
-        skip: true
+}`
       },
       {
         description: "a JSX element (cursor on closing tag)",
@@ -621,9 +622,9 @@ if (
   const extracted = <div className="text-lg font-weight-bold">
     {this.props.location.name}
   </div>;
+
   return extracted;
-}`,
-        skip: true
+}`
       },
       {
         description: "a nested JSX element",
@@ -635,11 +636,12 @@ if (
         selection: Selection.cursorAt(2, 6),
         expected: `function render() {
   const extracted = <p>{this.props.location.name}</p>;
-  return <div className="text-lg font-weight-bold">
-    {extracted}
-  </div>;
-}`,
-        skip: true
+  return (
+    <div className="text-lg font-weight-bold">
+      {extracted}
+    </div>
+  );
+}`
       },
       {
         description: "an error instance",

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -130,8 +130,7 @@ console.log(extracted);`
         code: `console.log([1, 2, 'three', [true, null]]);`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = [1, 2, 'three', [true, null]];
-console.log(extracted);`,
-        skip: true
+console.log(extracted);`
       },
       {
         description: "an array (multi-lines)",
@@ -141,13 +140,8 @@ console.log(extracted);`,
   [true, null]
 ]);`,
         selection: Selection.cursorAt(0, 12),
-        expected: `const extracted = [
-  1,
-  'Two',
-  [true, null]
-];
-console.log(extracted);`,
-        skip: true
+        expected: `const extracted = [1, 'Two', [true, null]];
+console.log(extracted);`
       },
       {
         description: "an object",

--- a/src/refactorings/extract-variable/extract-variable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.test.ts
@@ -4,7 +4,7 @@ import {
 } from "../../editor/i-delegate-to-editor";
 import { Code } from "../../editor/i-write-code";
 import { Selection } from "../../editor/selection";
-import { createReadThenWriteInMemory } from "../../editor/adapters/write-code-in-memory";
+import { createWriteInMemory } from "../../editor/adapters/write-code-in-memory";
 import {
   ShowErrorMessage,
   ErrorReason
@@ -95,42 +95,48 @@ console.log(extracted);`);
         code: `console.log("Hello!");`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = "Hello!";
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "a number",
         code: `console.log(12.5);`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = 12.5;
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "a boolean",
         code: `console.log(false);`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = false;
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "null",
         code: `console.log(null);`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = null;
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "undefined",
         code: `console.log(undefined);`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = undefined;
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "an array",
         code: `console.log([1, 2, 'three', [true, null]]);`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = [1, 2, 'three', [true, null]];
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "an array (multi-lines)",
@@ -145,14 +151,16 @@ console.log(extracted);`
   'Two',
   [true, null]
 ];
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "an object",
         code: `console.log({ one: 1, foo: true, hello: 'World!' });`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = { one: 1, foo: true, hello: 'World!' };
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "an object (multi-lines)",
@@ -167,7 +175,8 @@ console.log(extracted);`
   foo: true,
   hello: 'World!'
 };
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "a named function",
@@ -178,21 +187,24 @@ console.log(extracted);`
         expected: `const extracted = function sayHello() {
   return "Hello!";
 };
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "an arrow function",
         code: `console.log(() => "Hello!");`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = () => "Hello!";
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "a function call",
         code: `console.log(sayHello("World"));`,
         selection: Selection.cursorAt(0, 12),
         expected: `const extracted = sayHello("World");
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "the correct variable when we have many",
@@ -203,7 +215,8 @@ console.log("How are you doing?");`,
         expected: `console.log("Hello");
 const extracted = "World!";
 console.log("the", extracted, "Alright.");
-console.log("How are you doing?");`
+console.log("How are you doing?");`,
+        skip: true
       },
       {
         description: "a multi-lines object when cursor is inside",
@@ -218,7 +231,8 @@ console.log("How are you doing?");`
   foo: true,
   hello: 'World!'
 };
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "an element nested in a multi-lines object",
@@ -235,7 +249,8 @@ console.log({
   foo: {
     bar: extracted
   }
-});`
+});`,
+        skip: true
       },
       {
         description:
@@ -253,7 +268,8 @@ const a = {
   foo: {
     bar: extracted
   }
-};`
+};`,
+        skip: true
       },
       {
         description: "an element in a multi-lines array",
@@ -270,7 +286,8 @@ const SUPPORTED_LANGUAGES = [
   extracted,
   "typescript",
   "typescriptreact"
-];`
+];`,
+        skip: true
       },
       {
         description: "an element nested in a multi-lines array",
@@ -291,28 +308,32 @@ console.log([
       hello: extracted
     }
   ]
-]);`
+]);`,
+        skip: true
       },
       {
         description: "the whole object when cursor is on its property",
         code: `console.log({ foo: "bar", one: true });`,
         selection: Selection.cursorAt(0, 16),
         expected: `const extracted = { foo: "bar", one: true };
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "a computed object property",
         code: `const a = { [key]: "value" };`,
         selection: Selection.cursorAt(0, 13),
         expected: `const extracted = key;
-const a = { [extracted]: "value" };`
+const a = { [extracted]: "value" };`,
+        skip: true
       },
       {
         description: "a computed object property value when cursor is on value",
         code: `const a = { [key]: "value" };`,
         selection: Selection.cursorAt(0, 19),
         expected: `const extracted = "value";
-const a = { [key]: extracted };`
+const a = { [key]: extracted };`,
+        skip: true
       },
       {
         description: "the whole object when cursor is on a method declaration",
@@ -327,7 +348,8 @@ const a = { [key]: extracted };`
     return "bar";
   }
 };
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description:
@@ -335,14 +357,16 @@ console.log(extracted);`
         code: `console.log({ foo: { bar: true } });`,
         selection: Selection.cursorAt(0, 21),
         expected: `const extracted = { bar: true };
-console.log({ foo: extracted });`
+console.log({ foo: extracted });`,
+        skip: true
       },
       {
         description: "a spread variable",
         code: `console.log({ ...foo.bar });`,
         selection: Selection.cursorAt(0, 22),
         expected: `const extracted = { ...foo.bar };
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "a spread function result",
@@ -355,7 +379,8 @@ console.log(extracted);`
   ...getInlinableCode(declaration),
   id: "name"
 };
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description:
@@ -363,7 +388,8 @@ console.log(extracted);`
         code: `console.log(path.node.name);`,
         selection: Selection.cursorAt(0, 17),
         expected: `const extracted = path.node;
-console.log(extracted.name);`
+console.log(extracted.name);`,
+        skip: true
       },
       {
         description: "a return value of a function",
@@ -374,14 +400,16 @@ console.log(extracted.name);`
         expected: `function getMessage() {
   const extracted = "Hello!";
   return extracted;
-}`
+}`,
+        skip: true
       },
       {
         description: "an assigned variable",
         code: `const message = "Hello!";`,
         selection: Selection.cursorAt(0, 16),
         expected: `const extracted = "Hello!";
-const message = extracted;`
+const message = extracted;`,
+        skip: true
       },
       {
         description: "a class property assignment",
@@ -392,7 +420,8 @@ const message = extracted;`
         expected: `const extracted = "Hello!";
 class Logger {
   message = extracted;
-}`
+}`,
+        skip: true
       },
       {
         description: "a computed class property",
@@ -403,28 +432,32 @@ class Logger {
         expected: `const extracted = key;
 class Logger {
   [extracted] = "value";
-}`
+}`,
+        skip: true
       },
       {
         description: "an interpolated string when cursor is on a subpart of it",
         code: "console.log(`Hello ${world}! How are you doing?`);",
         selection: Selection.cursorAt(0, 15),
         expected: `const extracted = \`Hello \${world}! How are you doing?\`;
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "an if statement (whole statement)",
         code: "if (parents.length > 0 && type === 'refactor') doSomething();",
         selection: new Selection([0, 4], [0, 45]),
         expected: `const extracted = parents.length > 0 && type === 'refactor';
-if (extracted) doSomething();`
+if (extracted) doSomething();`,
+        skip: true
       },
       {
         description: "an if statement (part of it)",
         code: "if (parents.length > 0 && type === 'refactor') doSomething();",
         selection: new Selection([0, 4], [0, 22]),
         expected: `const extracted = parents.length > 0;
-if (extracted && type === 'refactor') doSomething();`
+if (extracted && type === 'refactor') doSomething();`,
+        skip: true
       },
       {
         description: "a multi-lines if statement (whole statement)",
@@ -437,7 +470,8 @@ if (extracted && type === 'refactor') doSomething();`
   type === 'refactor';
 if (
   extracted
-) doSomething();`
+) doSomething();`,
+        skip: true
       },
       {
         description: "a multi-lines if statement (part of it)",
@@ -450,7 +484,8 @@ if (
 if (
   parents.length > 0 &&
   extracted
-) doSomething();`
+) doSomething();`,
+        skip: true
       },
       {
         description: "a while statement",
@@ -458,7 +493,8 @@ if (
           "while (parents.length > 0 && type === 'refactor') doSomething();",
         selection: new Selection([0, 7], [0, 48]),
         expected: `const extracted = parents.length > 0 && type === 'refactor';
-while (extracted) doSomething();`
+while (extracted) doSomething();`,
+        skip: true
       },
       {
         description: "a case statement",
@@ -473,7 +509,8 @@ switch (text) {
   case extracted:
   default:
     break;
-}`
+}`,
+        skip: true
       },
       {
         description: "an unamed function parameter when cursor is inside",
@@ -484,7 +521,8 @@ switch (text) {
         expected: `const extracted = function () {
   return "Hello!";
 };
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "an exported variable declaration",
@@ -495,7 +533,8 @@ console.log(extracted);`
         expected: `const extracted = "bar";
 export const something = {
   foo: extracted
-};`
+};`,
+        skip: true
       },
       {
         description: "an object returned from arrow function",
@@ -506,7 +545,8 @@ export const something = {
         expected: `const extracted = "bar";
 const something = () => ({
   foo: extracted
-});`
+});`,
+        skip: true
       },
       {
         description: "a value inside an arrow function",
@@ -517,7 +557,8 @@ const something = () => ({
         expected: `const extracted = "Hello";
 () => (
   console.log(extracted)
-)`
+)`,
+        skip: true
       },
       {
         description: "an object from a nested call expression",
@@ -528,7 +569,8 @@ const something = () => ({
         expected: `const extracted = { context: ["value"] };
 assert.isTrue(
   getError(extracted)
-);`
+);`,
+        skip: true
       },
       {
         description: "a multi-lines ternary",
@@ -543,7 +585,8 @@ assert.isTrue(
   return isValid
     ? extracted
     : "no";
-}`
+}`,
+        skip: true
       },
       {
         description: "a multi-lines unary expression",
@@ -558,7 +601,8 @@ if (
   !(threshold > extracted || isPaused)
 ) {
   console.log("Ship it");
-}`
+}`,
+        skip: true
       },
       {
         description: "a variable in a JSX element",
@@ -574,7 +618,8 @@ if (
   return <div className="text-lg font-weight-bold">
     {extracted}
   </div>;
-}`
+}`,
+        skip: true
       },
       {
         description: "a JSX element (cursor on opening tag)",
@@ -589,7 +634,8 @@ if (
     {this.props.location.name}
   </div>;
   return extracted;
-}`
+}`,
+        skip: true
       },
       {
         description: "a JSX element (cursor on closing tag)",
@@ -604,7 +650,8 @@ if (
     {this.props.location.name}
   </div>;
   return extracted;
-}`
+}`,
+        skip: true
       },
       {
         description: "a nested JSX element",
@@ -619,14 +666,16 @@ if (
   return <div className="text-lg font-weight-bold">
     {extracted}
   </div>;
-}`
+}`,
+        skip: true
       },
       {
         description: "an error instance",
         code: `console.log(new Error("It failed"));`,
         selection: Selection.cursorAt(0, 14),
         expected: `const extracted = new Error("It failed");
-console.log(extracted);`
+console.log(extracted);`,
+        skip: true
       },
       {
         description: "a call expression parameter (multi-lines)",
@@ -641,7 +690,8 @@ createIfStatement(
   extracted,
   parentPath.node.left,
   node.consequent
-);`
+);`,
+        skip: true
       },
       {
         description: "a conditional expression (multi-lines)",
@@ -654,7 +704,8 @@ createIfStatement(
 const type = !!(
   extracted > 0
 ) ? "with-loc"
-  : "without-loc";`
+  : "without-loc";`,
+        skip: true
       },
       {
         description: "a value in a JSXExpressionContainer",
@@ -669,7 +720,8 @@ const type = !!(
   text={getTextForPerson({
     name: extracted
   })}
-/>`
+/>`,
+        skip: true
       },
       {
         description: "a value in a new Expression",
@@ -680,7 +732,8 @@ const type = !!(
         expected: `const extracted = "name";
 new Author(
   extracted
-);`
+);`,
+        skip: true
       },
       {
         description: "a value in an Array argument of a function",
@@ -691,7 +744,8 @@ new Author(
         expected: `const extracted = getValueOf("name");
 doSomething([
   extracted
-]);`
+]);`,
+        skip: true
       },
       {
         description: "a new Expression in an Array argument of a function",
@@ -702,7 +756,8 @@ doSomething([
         expected: `const extracted = new Author("Eliott");
 doSomething([
   extracted
-]);`
+]);`,
+        skip: true
       },
       {
         description: "a value in a binary expression",
@@ -715,7 +770,8 @@ doSomething([
 console.log(
   currentValue >
   extracted
-);`
+);`,
+        skip: true
       },
       {
         description: "an arrow function (cursor on params)",
@@ -726,7 +782,8 @@ console.log(
         expected: `const extracted = (name) => {
   console.log(name);
 };
-const sayHello = extracted;`
+const sayHello = extracted;`,
+        skip: true
       }
     ],
     async ({ code, selection, expected }) => {
@@ -735,7 +792,7 @@ const sayHello = extracted;`
     }
   );
 
-  it("should wrap extracted JSX element inside JSX Expression Container when inside another", async () => {
+  it.skip("should wrap extracted JSX element inside JSX Expression Container when inside another", async () => {
     const code = `function render() {
   return <div className="text-lg font-weight-bold">
     <p>{name}</p>
@@ -753,7 +810,7 @@ const sayHello = extracted;`
 }`);
   });
 
-  it("should not wrap extracted JSX element inside JSX Expression Container when not inside another", async () => {
+  it.skip("should not wrap extracted JSX element inside JSX Expression Container when not inside another", async () => {
     const code = `function render() {
   return <p>{name}</p>;
 }`;
@@ -777,19 +834,22 @@ const sayHello = extracted;`
         code: `function sayHello() {
   console.log("hello");
 }`,
-        selection: new Selection([0, 0], [2, 1])
+        selection: new Selection([0, 0], [2, 1]),
+        skip: true
       },
       {
         description: "a class property identifier",
         code: `class Logger {
   message = "Hello!";
 }`,
-        selection: new Selection([1, 2], [1, 9])
+        selection: new Selection([1, 2], [1, 9]),
+        skip: true
       },
       {
         description: "the identifier from a variable declaration",
         code: `const foo = "bar";`,
-        selection: new Selection([0, 6], [0, 9])
+        selection: new Selection([0, 6], [0, 9]),
+        skip: true
       }
     ],
     async ({ code, selection }) => {
@@ -803,14 +863,14 @@ const sayHello = extracted;`
     code: Code,
     selection: Selection
   ): Promise<Code> {
-    const [readThenWrite, getCode] = createReadThenWriteInMemory(code);
+    const [write, getCode] = createWriteInMemory(code);
     await extractVariable(
       code,
       selection,
-      readThenWrite,
+      write,
       showErrorMessage,
       delegateToEditor
     );
-    return getCode();
+    return getCode().code;
   }
 });

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -101,6 +101,7 @@ function extractInObjectProperty(
   path.node[nodeKey] = variableId();
 
   scopePath.stop();
+  scopePath.parentPath.stop();
 }
 
 function insertVariableBefore(

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -59,7 +59,9 @@ function updateCode(code: Code, selection: Selection): ast.Transformed {
     ArrowFunctionExpression: extractInSelectedNode,
     CallExpression: extractInSelectedNode,
     MemberExpression: extractInSelectedNode,
-    TemplateLiteral: extractInSelectedNode
+    TemplateLiteral: extractInSelectedNode,
+    LogicalExpression: extractInSelectedNode,
+    BinaryExpression: extractInSelectedNode
   });
 }
 
@@ -148,7 +150,8 @@ function hasChildWhichMatchesSelection(
     FunctionExpression: checkIfMatches,
     ArrowFunctionExpression: checkIfMatches,
     CallExpression: checkIfMatches,
-    MemberExpression: checkIfMatches
+    MemberExpression: checkIfMatches,
+    BinaryExpression: checkIfMatches
   });
 
   return result;
@@ -171,7 +174,10 @@ function findScopePath(
       ast.isExpressionStatement(parentPath) ||
       ast.isVariableDeclaration(parentPath) ||
       ast.isReturnStatement(parentPath) ||
-      ast.isClassDeclaration(parentPath)
+      ast.isClassDeclaration(parentPath) ||
+      ast.isIfStatement(parentPath) ||
+      ast.isWhileStatement(parentPath) ||
+      ast.isSwitchStatement(parentPath)
   );
 }
 

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -62,7 +62,8 @@ function updateCode(code: Code, selection: Selection): ast.Transformed {
     TemplateLiteral: extractInSelectedNode,
     LogicalExpression: extractInSelectedNode,
     BinaryExpression: extractInSelectedNode,
-    JSXElement: extractInSelectedNode
+    JSXElement: extractInSelectedNode,
+    NewExpression: extractInSelectedNode
   });
 }
 
@@ -162,7 +163,8 @@ function hasChildWhichMatchesSelection(
     CallExpression: checkIfMatches,
     MemberExpression: checkIfMatches,
     BinaryExpression: checkIfMatches,
-    JSXElement: checkIfMatches
+    JSXElement: checkIfMatches,
+    NewExpression: checkIfMatches
   });
 
   return result;

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -41,8 +41,8 @@ function updateCode(code: Code, selection: Selection): ast.Transformed {
     BooleanLiteral: extractInSelectedNode,
     NullLiteral: extractInSelectedNode,
     Identifier(path) {
-      if (isClassPropertyIdentifier(path)) return;
-      if (isVariableDeclarationIdentifier(path)) return;
+      if (ast.isClassPropertyIdentifier(path)) return;
+      if (ast.isVariableDeclarationIdentifier(path)) return;
       extractInSelectedNode(path);
     },
     ArrayExpression: extractInSelectedNode,
@@ -144,7 +144,7 @@ function hasChildWhichMatchesSelection(
     BooleanLiteral: checkIfMatches,
     NullLiteral: checkIfMatches,
     Identifier(childPath) {
-      if (isFunctionCallIdentifier(childPath)) return;
+      if (ast.isFunctionCallIdentifier(childPath)) return;
       if (ast.isMemberExpression(childPath.parent)) return;
       checkIfMatches(childPath);
     },
@@ -220,20 +220,4 @@ function isExtractableContext(node: ast.Node): boolean {
     ast.isSwitchCase(node) ||
     ast.isJSXExpressionContainer(node)
   );
-}
-
-function isFunctionCallIdentifier(path: ast.NodePath): boolean {
-  return ast.isCallExpression(path.parent) && path.parent.callee === path.node;
-}
-
-function isClassPropertyIdentifier(path: ast.NodePath): boolean {
-  return (
-    ast.isClassProperty(path.parent) &&
-    !path.parent.computed &&
-    ast.isIdentifier(path.node)
-  );
-}
-
-function isVariableDeclarationIdentifier(path: ast.NodePath): boolean {
-  return ast.isVariableDeclarator(path.parent) && ast.isIdentifier(path.node);
 }

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -40,7 +40,10 @@ function updateCode(code: Code, selection: Selection): ast.Transformed {
     NumericLiteral: extractInSelectedNode,
     BooleanLiteral: extractInSelectedNode,
     NullLiteral: extractInSelectedNode,
-    Identifier: extractInSelectedNode,
+    Identifier(path) {
+      if (isClassPropertyIdentifier(path)) return;
+      extractInSelectedNode(path);
+    },
     ArrayExpression: extractInSelectedNode,
     ObjectExpression: extractInSelectedNode,
     ObjectProperty(path) {
@@ -166,7 +169,8 @@ function findScopePath(
     parentPath =>
       ast.isExpressionStatement(parentPath) ||
       ast.isVariableDeclaration(parentPath) ||
-      ast.isReturnStatement(parentPath)
+      ast.isReturnStatement(parentPath) ||
+      ast.isClassDeclaration(parentPath)
   );
 }
 
@@ -198,4 +202,12 @@ function isExtractableContext(node: ast.Node): boolean {
 
 function isFunctionCallIdentifier(path: ast.NodePath): boolean {
   return ast.isCallExpression(path.parent) && path.parent.callee === path.node;
+}
+
+function isClassPropertyIdentifier(path: ast.NodePath): boolean {
+  return (
+    ast.isClassProperty(path.parent) &&
+    !path.parent.computed &&
+    ast.isIdentifier(path.node)
+  );
 }

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -165,7 +165,8 @@ function findScopePath(
   return path.findParent(
     parentPath =>
       ast.isExpressionStatement(parentPath) ||
-      ast.isVariableDeclaration(parentPath)
+      ast.isVariableDeclaration(parentPath) ||
+      ast.isReturnStatement(parentPath)
   );
 }
 

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -36,7 +36,8 @@ function updateCode(code: Code, selection: Selection): ast.Transformed {
     NumericLiteral: visitor,
     BooleanLiteral: visitor,
     NullLiteral: visitor,
-    Identifier: visitor
+    Identifier: visitor,
+    ArrayExpression: visitor
   });
 
   function visitor(path: ast.NodePath<ast.VariableDeclarator["init"]>) {

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -14,8 +14,8 @@ async function extractVariable(
   code: Code,
   selection: Selection,
   readThenWrite: ReadThenWrite,
-  delegateToEditor: DelegateToEditor,
-  showErrorMessage: ShowErrorMessage
+  showErrorMessage: ShowErrorMessage,
+  delegateToEditor: DelegateToEditor
 ) {
   const { path, loc, shouldWrapInJSXExpressionContainer } = findExtractableCode(
     code,

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -58,7 +58,8 @@ function updateCode(code: Code, selection: Selection): ast.Transformed {
     FunctionExpression: extractInSelectedNode,
     ArrowFunctionExpression: extractInSelectedNode,
     CallExpression: extractInSelectedNode,
-    MemberExpression: extractInSelectedNode
+    MemberExpression: extractInSelectedNode,
+    TemplateLiteral: extractInSelectedNode
   });
 }
 

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -54,7 +54,8 @@ function updateCode(code: Code, selection: Selection): ast.Transformed {
     },
     FunctionExpression: extractInSelectedNode,
     ArrowFunctionExpression: extractInSelectedNode,
-    CallExpression: extractInSelectedNode
+    CallExpression: extractInSelectedNode,
+    MemberExpression: extractInSelectedNode
   });
 }
 
@@ -126,7 +127,7 @@ function hasChildWhichMatchesSelection(
     NullLiteral: checkIfMatches,
     Identifier(childPath) {
       if (isFunctionCallIdentifier(childPath)) return;
-      if (isPartOfMemberExpression(childPath)) return;
+      if (ast.isMemberExpression(childPath.parent)) return;
       checkIfMatches(childPath);
     },
     ArrayExpression: checkIfMatches,
@@ -142,7 +143,8 @@ function hasChildWhichMatchesSelection(
     },
     FunctionExpression: checkIfMatches,
     ArrowFunctionExpression: checkIfMatches,
-    CallExpression: checkIfMatches
+    CallExpression: checkIfMatches,
+    MemberExpression: checkIfMatches
   });
 
   return result;
@@ -195,8 +197,4 @@ function isExtractableContext(node: ast.Node): boolean {
 
 function isFunctionCallIdentifier(path: ast.NodePath): boolean {
   return ast.isCallExpression(path.parent) && path.parent.callee === path.node;
-}
-
-function isPartOfMemberExpression(path: ast.NodePath): boolean {
-  return ast.isIdentifier(path.node) && ast.isMemberExpression(path.parent);
 }

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -1,4 +1,4 @@
-import { ReadThenWrite, Code } from "../../editor/i-write-code";
+import { Code, Write } from "../../editor/i-write-code";
 import { DelegateToEditor } from "../../editor/i-delegate-to-editor";
 import {
   ShowErrorMessage,
@@ -13,137 +13,37 @@ export { extractVariable };
 async function extractVariable(
   code: Code,
   selection: Selection,
-  readThenWrite: ReadThenWrite,
+  write: Write,
   showErrorMessage: ShowErrorMessage,
   delegateToEditor: DelegateToEditor
 ) {
-  const { path, loc, shouldWrapInJSXExpressionContainer } = findExtractableCode(
-    code,
-    selection
-  );
+  const updatedCode = updateCode(code, selection);
 
-  if (!path || !loc) {
+  if (!updatedCode.hasCodeChanged) {
     showErrorMessage(ErrorReason.DidNotFoundExtractableCode);
     return;
   }
 
-  const variableName = "extracted";
-  const extractedCodeSelection = Selection.fromAST(loc);
-  const indentation = " ".repeat(
-    extractedCodeSelection.getIndentationLevel(path)
-  );
-
-  await readThenWrite(extractedCodeSelection, extractedCode => [
-    // Insert new variable declaration.
-    {
-      code: `const ${variableName} = ${extractedCode};\n${indentation}`,
-      selection: extractedCodeSelection.putCursorAtScopeParentPosition(path)
-    },
-    // Replace extracted code with new variable.
-    {
-      code: shouldWrapInJSXExpressionContainer
-        ? `{${variableName}}`
-        : variableName,
-      selection: extractedCodeSelection
-    }
-  ]);
+  await write(updatedCode.code);
 
   // Extracted symbol is located at `selection` => just trigger a rename.
   await renameSymbol(delegateToEditor);
 }
 
-function findExtractableCode(
-  code: Code,
-  selection: Selection
-): ExtractableCode {
-  let result: ExtractableCode = {
-    path: undefined,
-    loc: undefined,
-    shouldWrapInJSXExpressionContainer: false
-  };
+function updateCode(code: Code, selection: Selection): ast.Transformed {
+  return ast.transform(code, {
+    StringLiteral(path) {
+      if (!selection.isInsidePath(path)) return;
 
-  ast.traverseAST(code, {
-    enter(path) {
-      if (!isExtractableContext(path.parent)) return;
-
-      if (isPartOfMemberExpression(path)) return;
-      if (isClassPropertyIdentifier(path)) return;
-      if (isVariableDeclarationIdentifier(path)) return;
-      if (isFunctionCallIdentifier(path)) return;
-      if (isJSXPartialElement(path)) return;
-      if (ast.isTemplateElement(path)) return;
-      if (ast.isBlockStatement(path)) return;
-      if (ast.isSpreadElement(path)) return;
-      // Don't extract object method because we don't handle `this`.
-      if (ast.isObjectMethod(path)) return;
-
-      const { node } = path;
-      if (!selection.isInsideNode(node)) return;
-
-      result.path = path;
-      result.loc = ast.isObjectProperty(node)
-        ? findObjectPropertyLoc(selection, node) || result.loc
-        : ast.isJSXExpressionContainer(node)
-        ? node.expression.loc || result.loc
-        : node.loc;
-      result.shouldWrapInJSXExpressionContainer =
-        ast.isJSXElement(node) && ast.isJSX(path.parent);
+      const variableId = ast.identifier("extracted");
+      const scopePath = path.parentPath;
+      scopePath.insertBefore([
+        ast.variableDeclaration("const", [
+          ast.variableDeclarator(variableId, path.node)
+        ])
+      ]);
+      path.replaceWith(variableId);
+      scopePath.parentPath.stop();
     }
   });
-
-  return result;
 }
-
-function findObjectPropertyLoc(
-  selection: Selection,
-  node: ast.SelectableObjectProperty
-): ast.SourceLocation | null {
-  if (selection.isInsideNode(node.value)) return node.value.loc;
-  if (node.computed) return node.key.loc;
-
-  // Non-computed properties can't be extracted.
-  // It will extract the whole object instead.
-  return null;
-}
-
-function isExtractableContext(node: ast.Node): boolean {
-  return (
-    (ast.isExpression(node) && !ast.isArrowFunctionExpression(node)) ||
-    ast.isReturnStatement(node) ||
-    ast.isVariableDeclarator(node) ||
-    ast.isClassProperty(node) ||
-    ast.isIfStatement(node) ||
-    ast.isWhileStatement(node) ||
-    ast.isSwitchCase(node)
-  );
-}
-
-function isClassPropertyIdentifier(path: ast.NodePath): boolean {
-  return (
-    ast.isClassProperty(path.parent) &&
-    !path.parent.computed &&
-    ast.isIdentifier(path.node)
-  );
-}
-
-function isVariableDeclarationIdentifier(path: ast.NodePath): boolean {
-  return ast.isVariableDeclarator(path.parent) && ast.isIdentifier(path.node);
-}
-
-function isFunctionCallIdentifier(path: ast.NodePath): boolean {
-  return ast.isCallExpression(path.parent) && path.parent.callee === path.node;
-}
-
-function isJSXPartialElement(path: ast.NodePath): boolean {
-  return ast.isJSXOpeningElement(path) || ast.isJSXClosingElement(path);
-}
-
-function isPartOfMemberExpression(path: ast.NodePath): boolean {
-  return ast.isIdentifier(path.node) && ast.isMemberExpression(path.parent);
-}
-
-type ExtractableCode = {
-  path: ast.NodePath | undefined;
-  loc: ast.SourceLocation | undefined;
-  shouldWrapInJSXExpressionContainer: boolean;
-};

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -42,6 +42,7 @@ function updateCode(code: Code, selection: Selection): ast.Transformed {
     NullLiteral: extractInSelectedNode,
     Identifier(path) {
       if (isClassPropertyIdentifier(path)) return;
+      if (isVariableDeclarationIdentifier(path)) return;
       extractInSelectedNode(path);
     },
     ArrayExpression: extractInSelectedNode,
@@ -231,4 +232,8 @@ function isClassPropertyIdentifier(path: ast.NodePath): boolean {
     !path.parent.computed &&
     ast.isIdentifier(path.node)
   );
+}
+
+function isVariableDeclarationIdentifier(path: ast.NodePath): boolean {
+  return ast.isVariableDeclarator(path.parent) && ast.isIdentifier(path.node);
 }


### PR DESCRIPTION
"Extract Variable" was one of the first refactorings I implemented. When I did it, I didn't transformed the AST. Instead, I got information from it, then asked VS Code to read the code and manipulated the strings.

While it was working, it bothered me for few reasons:
1. Inconsistency with the other refactorings, since the approach was different
1. Custom code in Selection that was only used for this use case, because of the approach
1. Necessity to have and maintain a `ReadThenWrite` adapter (there are still 2 refactorings using it)
1. Make it harder to combine with other refactorings because it doesn't depend on the same adapter 
1. Because we were counting on strings, edge cases implied adding more custom code that couldn't be re-used (e.g. JSX flags for adding `{` around `extracted`). Using an appropriate model (👋 AST) should limit that.

Each of these reasons could have been solved with other techniques, but rewriting the refactoring to use the same approach solved them all.

All the 68 tests I wrote to cover this feature still pass. If this introduces a regression, it would be on patterns I didn't test before.

## What changes

As the extracted code is a new node in the AST, extracted objects / arrays will be formatted. Whereas before, it was the exact text string that was cut & pasted. 

```js
console.log({ firstName: "Jane", lastName: "Doe" });
```

Extraction, before this PR:

```js
const extracted = { firstName: "Jane", lastName: "Doe" };
console.log(extracted);
```

Extraction, after this PR:

```js
const extracted = {
  firstName: "Jane", 
  lastName: "Doe" 
};

console.log(extracted);
```

Before was better. But I'm OK to accept the tradeoff for the moment and see how it goes (my code is usually formatted on save/commit, so I'm fine). 

If that cause you troubles, I count on you to tell me ;-) 

## Remaining work

- [ ] Set cursor position after rewrite to be on the new variable identifier (should fix issue with JSX extractions that didn't get renamed because of `{`)
- [ ] Update Changelog