### PR TITLE
Flip If/Else now handle guard clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Flip If/Else now works better on [guard clause][guard-clause] patterns
+
+Consider this guard clause example:
+
+```js
+function doSomething(someData) {
+  if (!isValid(someData)) {
+    return;
+  }
+
+  // … rest of the code
+}
+```
+
+Before, running _Flip If/Else_ would have produced:
+
+```js
+function doSomething(someData) {
+  if (isValid(someData)) {
+  } else {
+    return;
+  }
+
+  // … rest of the code
+}
+```
+
+Which is valid, but probably not what had in mind.
+
+Now, it would produce the following result:
+
+```js
+function doSomething(someData) {
+  if (isValid(someData)) {
+    // … rest of the code
+  }
+}
+```
+
 ### Fixed
 
 - Extract Variable on JSX Elements now triggers symbol rename as expected
@@ -68,3 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/nicoespeon/abracadabra/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/nicoespeon/abracadabra/compare/0.0.1...0.1.0
 [0.0.1]: https://github.com/nicoespeon/abracadabra/compare/224558fafc2c9247b637a74a7f17fe3c62140d47...0.0.1
+
+<!-- Links -->
+
+[guard-clause]: https://deviq.com/guard-clause/

--- a/src/array-helpers.ts
+++ b/src/array-helpers.ts
@@ -1,0 +1,9 @@
+export { last, allButLast };
+
+function last<T>(array: T[] | ReadonlyArray<T>): T {
+  return array[array.length - 1];
+}
+
+function allButLast<T>(array: T[]): T[] {
+  return array.slice(0, -1);
+}

--- a/src/ast/domain.ts
+++ b/src/ast/domain.ts
@@ -1,6 +1,8 @@
 import { NodePath } from "@babel/traverse";
 import * as t from "@babel/types";
 
+import { last } from "../array-helpers";
+
 export * from "@babel/types";
 export {
   isArrayExpressionElement,
@@ -42,8 +44,7 @@ function isGuardConsequentBlock(
   consequent: t.IfStatement["consequent"]
 ): consequent is t.BlockStatement {
   return (
-    t.isBlockStatement(consequent) &&
-    t.isReturnStatement(consequent.body[consequent.body.length - 1])
+    t.isBlockStatement(consequent) && t.isReturnStatement(last(consequent.body))
   );
 }
 

--- a/src/ast/domain.ts
+++ b/src/ast/domain.ts
@@ -1,3 +1,4 @@
+import { NodePath } from "@babel/traverse";
 import * as t from "@babel/types";
 
 export * from "@babel/types";
@@ -5,6 +6,7 @@ export {
   isArrayExpressionElement,
   areAllObjectProperties,
   isUndefinedLiteral,
+  isGuardClause,
   isTemplateExpression,
   templateElement,
   Primitive
@@ -27,6 +29,10 @@ function isUndefinedLiteral(
   opts?: object | null
 ): node is t.Identifier {
   return t.isIdentifier(node, opts) && node.name === "undefined";
+}
+
+function isGuardClause(path: NodePath<t.IfStatement>) {
+  return t.isReturnStatement(path.node.consequent);
 }
 
 function isTemplateExpression(node: t.Node): node is TemplateExpression {

--- a/src/ast/domain.ts
+++ b/src/ast/domain.ts
@@ -10,7 +10,7 @@ export {
   isUndefinedLiteral,
   isGuardClause,
   isGuardConsequentBlock,
-  isEmptyReturn,
+  isNonEmptyReturn,
   isTemplateExpression,
   templateElement,
   Primitive
@@ -48,8 +48,8 @@ function isGuardConsequentBlock(
   );
 }
 
-function isEmptyReturn(node: t.Node) {
-  return t.isReturnStatement(node) && node.argument === null;
+function isNonEmptyReturn(node: t.Node) {
+  return t.isReturnStatement(node) && node.argument !== null;
 }
 
 function isTemplateExpression(node: t.Node): node is TemplateExpression {

--- a/src/ast/domain.ts
+++ b/src/ast/domain.ts
@@ -7,6 +7,8 @@ export {
   areAllObjectProperties,
   isUndefinedLiteral,
   isGuardClause,
+  isGuardConsequentBlock,
+  isEmptyReturn,
   isTemplateExpression,
   templateElement,
   Primitive
@@ -32,7 +34,21 @@ function isUndefinedLiteral(
 }
 
 function isGuardClause(path: NodePath<t.IfStatement>) {
-  return t.isReturnStatement(path.node.consequent);
+  const { consequent } = path.node;
+  return t.isReturnStatement(consequent) || isGuardConsequentBlock(consequent);
+}
+
+function isGuardConsequentBlock(
+  consequent: t.IfStatement["consequent"]
+): consequent is t.BlockStatement {
+  return (
+    t.isBlockStatement(consequent) &&
+    t.isReturnStatement(consequent.body[consequent.body.length - 1])
+  );
+}
+
+function isEmptyReturn(node: t.Node) {
+  return t.isReturnStatement(node) && node.argument === null;
 }
 
 function isTemplateExpression(node: t.Node): node is TemplateExpression {

--- a/src/refactorings/flip-if-else/flip-if-else.test.ts
+++ b/src/refactorings/flip-if-else/flip-if-else.test.ts
@@ -211,7 +211,6 @@ doSomethingElse();`,
   return null;
 }`
       }
-      // TODO: other nodes than statements after the guard?
     ],
     async ({ code, selection = Selection.cursorAt(0, 0), expected }) => {
       const result = await doFlipIfElse(code, selection);

--- a/src/refactorings/flip-if-else/flip-if-else.test.ts
+++ b/src/refactorings/flip-if-else/flip-if-else.test.ts
@@ -197,9 +197,24 @@ doSomethingElse();`,
   doSomething();
   doSomethingElse();
 } else {
-  return null
-}`,
-        skip: true
+  return null;
+}`
+      },
+      {
+        description: "guard clause with returned value in block",
+        code: `if (!isValid) {
+  return null;
+}
+
+doSomething();
+doSomethingElse();`,
+        selection: Selection.cursorAt(0, 16),
+        expected: `if (isValid) {
+  doSomething();
+  doSomethingElse();
+} else {
+  return null;
+}`
       }
       // TODO: other nodes than statements after the guard?
     ],

--- a/src/refactorings/flip-if-else/flip-if-else.test.ts
+++ b/src/refactorings/flip-if-else/flip-if-else.test.ts
@@ -135,7 +135,6 @@ describe("Flip If/Else", () => {
 
 doSomething();
 doSomethingElse();`,
-        selection: Selection.cursorAt(0, 16),
         expected: `if (isValid) {
   doSomething();
   doSomethingElse();
@@ -149,7 +148,6 @@ doSomethingElse();`,
 
 doSomething();
 doSomethingElse();`,
-        selection: Selection.cursorAt(0, 16),
         expected: `if (isValid) {
   doSomething();
   doSomethingElse();
@@ -164,7 +162,6 @@ doSomethingElse();`,
 
 doSomething();
 doSomethingElse();`,
-        selection: Selection.cursorAt(0, 16),
         expected: `if (isValid) {
   doSomething();
   doSomethingElse();
@@ -192,7 +189,6 @@ if (isValid) {
 
 doSomething();
 doSomethingElse();`,
-        selection: Selection.cursorAt(0, 16),
         expected: `if (isValid) {
   doSomething();
   doSomethingElse();
@@ -208,7 +204,6 @@ doSomethingElse();`,
 
 doSomething();
 doSomethingElse();`,
-        selection: Selection.cursorAt(0, 16),
         expected: `if (isValid) {
   doSomething();
   doSomethingElse();

--- a/src/refactorings/flip-if-else/flip-if-else.test.ts
+++ b/src/refactorings/flip-if-else/flip-if-else.test.ts
@@ -128,6 +128,18 @@ describe("Flip If/Else", () => {
 } else {
   doAnotherThing();
 }`
+      },
+      {
+        description: "guard clause",
+        code: `if (!isValid) return;
+
+doSomething();
+doSomethingElse();`,
+        selection: Selection.cursorAt(0, 16),
+        expected: `if (isValid) {
+  doSomething();
+  doSomethingElse();
+}`
       }
     ],
     async ({ code, selection = Selection.cursorAt(0, 0), expected }) => {

--- a/src/refactorings/flip-if-else/flip-if-else.test.ts
+++ b/src/refactorings/flip-if-else/flip-if-else.test.ts
@@ -140,7 +140,68 @@ doSomethingElse();`,
   doSomething();
   doSomethingElse();
 }`
+      },
+      {
+        description: "guard clause with block statement",
+        code: `if (!isValid) {
+  return;
+}
+
+doSomething();
+doSomethingElse();`,
+        selection: Selection.cursorAt(0, 16),
+        expected: `if (isValid) {
+  doSomething();
+  doSomethingElse();
+}`
+      },
+      {
+        description: "guard clause with other statements in block",
+        code: `if (!isValid) {
+  console.log("Hello");
+  return;
+}
+
+doSomething();
+doSomethingElse();`,
+        selection: Selection.cursorAt(0, 16),
+        expected: `if (isValid) {
+  doSomething();
+  doSomethingElse();
+} else {
+  console.log("Hello");
+}`
+      },
+      {
+        description: "guard clause with other statements above",
+        code: `console.log("Hello");
+if (!isValid) return;
+
+doSomething();
+doSomethingElse();`,
+        selection: Selection.cursorAt(1, 16),
+        expected: `console.log("Hello");
+if (isValid) {
+  doSomething();
+  doSomethingElse();
+}`
+      },
+      {
+        description: "guard clause with returned value",
+        code: `if (!isValid) return null;
+
+doSomething();
+doSomethingElse();`,
+        selection: Selection.cursorAt(0, 16),
+        expected: `if (isValid) {
+  doSomething();
+  doSomethingElse();
+} else {
+  return null
+}`,
+        skip: true
       }
+      // TODO: other nodes than statements after the guard?
     ],
     async ({ code, selection = Selection.cursorAt(0, 0), expected }) => {
       const result = await doFlipIfElse(code, selection);

--- a/src/refactorings/flip-if-else/flip-if-else.ts
+++ b/src/refactorings/flip-if-else/flip-if-else.ts
@@ -59,6 +59,7 @@ function flipIfStatement(path: ast.NodePath<ast.IfStatement>) {
 }
 
 function flipGuardClause(path: ast.NodePath<ast.IfStatement>) {
+  const ifBranch = path.node.consequent;
   const pathsBelow = path
     .getAllNextSiblings()
     .filter(
@@ -67,8 +68,19 @@ function flipGuardClause(path: ast.NodePath<ast.IfStatement>) {
   const nodesBelow: ast.Statement[] = pathsBelow.map(path => path.node);
 
   path.node.consequent = ast.blockStatement(nodesBelow);
-  path.node.alternate = null;
+  path.node.alternate = flipToGuardAlternate(ifBranch);
   pathsBelow.forEach(path => path.remove());
+}
+
+function flipToGuardAlternate(
+  ifBranch: ast.Statement
+): ast.BlockStatement | null {
+  if (!ast.isGuardConsequentBlock(ifBranch)) return null;
+
+  const body = ifBranch.body.slice(0, -1);
+  if (body.length === 0) return null;
+
+  return ast.blockStatement(body);
 }
 
 function hasChildWhichMatchesSelection(

--- a/src/refactorings/inline-variable-or-function/inline-variable.ts
+++ b/src/refactorings/inline-variable-or-function/inline-variable.ts
@@ -1,6 +1,7 @@
 import { Editor, Code, ErrorReason } from "../../editor/editor";
 import { Selection } from "../../editor/selection";
 import * as ast from "../../ast";
+import { last } from "../../array-helpers";
 
 import { findExportedIdNames } from "./find-exported-id-names";
 
@@ -161,7 +162,7 @@ function findIdentifiersToReplace(
       const isSameIdentifier = selection.isInsideNode(id);
       if (isSameIdentifier) return;
 
-      const parent = ancestors[ancestors.length - 1];
+      const parent = last(ancestors);
       if (ast.isFunctionDeclaration(parent)) return;
       if (ast.isObjectProperty(parent.node) && parent.node.key === node) return;
       if (

--- a/src/refactorings/remove-redundant-else/remove-redundant-else.ts
+++ b/src/refactorings/remove-redundant-else/remove-redundant-else.ts
@@ -1,6 +1,7 @@
 import { Editor, Code, ErrorReason } from "../../editor/editor";
 import { Selection } from "../../editor/selection";
 import * as ast from "../../ast";
+import { last } from "../../array-helpers";
 
 export { removeRedundantElse, hasRedundantElse };
 
@@ -81,7 +82,7 @@ function hasChildWhichMatchesSelection(
 }
 
 function hasExitStatement(node: ast.BlockStatement): boolean {
-  const lastStatement = node.body[node.body.length - 1];
+  const lastStatement = last(node.body);
 
   return (
     ast.isReturnStatement(lastStatement) || ast.isThrowStatement(lastStatement)


### PR DESCRIPTION
Consider this guard clause example:

```js
function doSomething(someData) {
  if (!isValid(someData)) {
    return;
  }

  // … rest of the code
}
```

Before, running _Flip If/Else_ would have produced:

```js
function doSomething(someData) {
  if (isValid(someData)) {
  } else {
    return;
  }

  // … rest of the code
}
```

Which is valid, but probably not what had in mind.

Now, it would produce the following result:

```js
function doSomething(someData) {
  if (isValid(someData)) {
    // … rest of the code
  }
}
```