### PR TITLE
[Extract Variable] Infer variable name on String Literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,36 @@ console.log(names[0]);
 
 That means Inline Variable now handles all kind of destructured variables. Making it much more flexible and handy!
 
+### Extract Variable infers variable name on String Literals
+
+Consider the following code:
+
+```js
+console.log("Hello World!");
+```
+
+If you extracted `"Hello World!"`, you would end up with the following code:
+
+```js
+const extracted = "Hello World!";
+console.log(extracted);
+```
+
+And you'll be renaming the `extracted` symbol. Which is a quick and efficient way to extract the variable.
+
+But now, it'll try to do a bit better. Now, you'll end up with:
+
+```js
+const helloWorld = "Hello World!";
+console.log(helloWorld);
+```
+
+Which would make sense in that case, saving you the trouble of naming it!
+
+Now, predicting the variable name is **hard**. Thus, you'll still be in "renaming mode", so it doesn't really matter if the guess is wrong. If it's correct though, it will certainly save you some more time in your refactoring, and that's the goal!
+
+One last thing: if the inferred name is too long (> 20 characters), it will default on `"extracted"` because it's probably not a good name for your variable.
+
 ### Fixed
 
 - All refactorings Quick Fixes used to appear on Windows because of EOL. Not anymore!

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@babel/parser": "7.4.5",
     "@babel/traverse": "7.4.5",
     "@babel/types": "7.4.4",
+    "change-case": "3.1.0",
     "pluralize": "8.0.0",
     "recast": "0.18.1"
   },

--- a/src/refactorings/extract-variable/extract-variable.basic-extraction.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.basic-extraction.test.ts
@@ -20,8 +20,8 @@ describe("Extract Variable - Basic extraction behaviour", () => {
   it("should update code with extractable selection", async () => {
     const result = await doExtractVariable(code, extractableSelection);
 
-    expect(result.code).toBe(`const extracted = "Hello!";
-console.log(extracted);`);
+    expect(result.code).toBe(`const hello = "Hello!";
+console.log(hello);`);
   });
 
   it("should expand selection to the nearest extractable code", async () => {
@@ -29,8 +29,8 @@ console.log(extracted);`);
 
     const result = await doExtractVariable(code, selectionInExtractableCode);
 
-    expect(result.code).toBe(`const extracted = "Hello!";
-console.log(extracted);`);
+    expect(result.code).toBe(`const hello = "Hello!";
+console.log(hello);`);
   });
 
   it("should rename extracted symbol", async () => {
@@ -49,8 +49,8 @@ console.log(extracted);`);
     const result = await doExtractVariable(code, extractableSelection);
 
     expect(result.code).toBe(`    function sayHello() {
-      const extracted = "Hello!";
-      console.log(extracted);
+      const hello = "Hello!";
+      console.log(hello);
     }`);
   });
 

--- a/src/refactorings/extract-variable/extract-variable.extractable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.extractable.test.ts
@@ -19,8 +19,8 @@ describe("Extract Variable - Patterns we can extract", () => {
         description: "a string",
         code: `console.log("Hello!");`,
         selection: Selection.cursorAt(0, 12),
-        expected: `const extracted = "Hello!";
-console.log(extracted);`
+        expected: `const hello = "Hello!";
+console.log(hello);`
       },
       {
         description: "a number",
@@ -126,8 +126,8 @@ console.log("the", "World!", "Alright.");
 console.log("How are you doing?");`,
         selection: Selection.cursorAt(1, 19),
         expected: `console.log("Hello");
-const extracted = "World!";
-console.log("the", extracted, "Alright.");
+const world = "World!";
+console.log("the", world, "Alright.");
 console.log("How are you doing?");`
       },
       {
@@ -189,10 +189,10 @@ const a = {
   "typescriptreact"
 ];`,
         selection: Selection.cursorAt(2, 2),
-        expected: `const extracted = "javascriptreact";
+        expected: `const javascriptreact = "javascriptreact";
 const SUPPORTED_LANGUAGES = [
   "javascript",
-  extracted,
+  javascriptreact,
   "typescript",
   "typescriptreact"
 ];`
@@ -304,16 +304,16 @@ console.log(extracted.name);`
 }`,
         selection: Selection.cursorAt(1, 9),
         expected: `function getMessage() {
-  const extracted = "Hello!";
-  return extracted;
+  const hello = "Hello!";
+  return hello;
 }`
       },
       {
         description: "an assigned variable",
         code: `const message = "Hello!";`,
         selection: Selection.cursorAt(0, 16),
-        expected: `const extracted = "Hello!";
-const message = extracted;`
+        expected: `const hello = "Hello!";
+const message = hello;`
       },
       {
         description: "a class property assignment",
@@ -321,9 +321,9 @@ const message = extracted;`
   message = "Hello!";
 }`,
         selection: Selection.cursorAt(1, 12),
-        expected: `const extracted = "Hello!";
+        expected: `const hello = "Hello!";
 class Logger {
-  message = extracted;
+  message = hello;
 }`
       },
       {
@@ -400,9 +400,9 @@ while (extracted) doSomething();`
     break;
 }`,
         selection: Selection.cursorAt(1, 7),
-        expected: `const extracted = "Hello!";
+        expected: `const hello = "Hello!";
 switch (text) {
-  case extracted:
+  case hello:
   default:
     break;
 }`
@@ -446,9 +446,9 @@ const something = () => ({
   console.log("Hello")
 )`,
         selection: Selection.cursorAt(1, 16),
-        expected: `const extracted = "Hello";
+        expected: `const hello = "Hello";
 () => (
-  console.log(extracted)
+  console.log(hello)
 )`
       },
       {
@@ -471,9 +471,9 @@ assert.isTrue(
 }`,
         selection: Selection.cursorAt(2, 8),
         expected: `function getText() {
-  const extracted = "yes";
+  const yes = "yes";
   return isValid
-    ? extracted
+    ? yes
     : "no";
 }`
       },
@@ -623,9 +623,9 @@ const type = !!(
   "name"
 );`,
         selection: Selection.cursorAt(1, 2),
-        expected: `const extracted = "name";
+        expected: `const name = "name";
 new Author(
-  extracted
+  name
 );`
       },
       {

--- a/src/refactorings/extract-variable/extract-variable.multiple-occurrences.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.multiple-occurrences.test.ts
@@ -62,8 +62,8 @@ sendMessage("Hello");`;
 
     const result = await doExtractVariable(code, selection);
 
-    const expectedCode = `const extracted = "Hello";
-console.log(extracted);
+    const expectedCode = `const hello = "Hello";
+console.log(hello);
 sendMessage("Hello");`;
     expect(result.code).toBe(expectedCode);
   });
@@ -76,9 +76,9 @@ sendMessage("Hello");`;
 
     const result = await doExtractVariable(code, selection);
 
-    const expectedCode = `const extracted = "Hello";
-console.log(extracted);
-sendMessage(extracted);`;
+    const expectedCode = `const hello = "Hello";
+console.log(hello);
+sendMessage(hello);`;
     expect(result.code).toBe(expectedCode);
   });
 
@@ -90,9 +90,9 @@ sendMessage("Hello");`;
 
     const result = await doExtractVariable(code, selection);
 
-    const expectedCode = `const extracted = "Hello";
-console.log(extracted);
-sendMessage(extracted);`;
+    const expectedCode = `const hello = "Hello";
+console.log(hello);
+sendMessage(hello);`;
     expect(result.code).toBe(expectedCode);
   });
 
@@ -109,9 +109,9 @@ sendMessage("Hello");`;
     const result = await doExtractVariable(code, selection);
 
     const expectedCode = `function sayHello() {
-  const extracted = "Hello";
-  track("said", extracted);
-  console.log(extracted);
+  const hello = "Hello";
+  track("said", hello);
+  console.log(hello);
 }
 
 sendMessage("Hello");`;
@@ -125,9 +125,9 @@ sendMessage("Hello");`;
         description: "string",
         code: `console.log("Hello");
 sendMessage("Hello");`,
-        expected: `const extracted = "Hello";
-console.log(extracted);
-sendMessage(extracted);`
+        expected: `const hello = "Hello";
+console.log(hello);
+sendMessage(hello);`
       },
       {
         description: "number",

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -1,3 +1,5 @@
+import { camel } from "change-case";
+
 import { Editor, Code, ErrorReason } from "../../editor/editor";
 import { Selection } from "../../editor/selection";
 import { Position } from "../../editor/position";
@@ -216,6 +218,10 @@ class Occurrence {
   constructor(path: ast.NodePath, loc: ast.SourceLocation) {
     this.path = path;
     this.loc = loc;
+
+    if (ast.isStringLiteral(path.node)) {
+      this.variableName = camel(path.node.value);
+    }
   }
 
   get selection() {

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -213,7 +213,8 @@ type ExtractableCode = {
 class Occurrence {
   path: ast.NodePath;
   loc: ast.SourceLocation;
-  private variableName = "extracted";
+
+  private variableName: string = "";
 
   constructor(path: ast.NodePath, loc: ast.SourceLocation) {
     this.path = path;
@@ -221,6 +222,10 @@ class Occurrence {
 
     if (ast.isStringLiteral(path.node)) {
       this.variableName = camel(path.node.value);
+    }
+
+    if (!this.variableName || this.variableName.length > 20) {
+      this.variableName = "extracted";
     }
   }
 

--- a/src/refactorings/extract-variable/extract-variable.variable-name.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.variable-name.test.ts
@@ -14,6 +14,29 @@ describe("Extract Variable - Variable name", () => {
         code: `console.log("Hello world!");`,
         expected: `const helloWorld = "Hello world!";
 console.log(helloWorld);`
+      },
+      {
+        description: "a name that would be 20 characters",
+        code: `console.log("Hello world, how do you do?");`,
+        expected: `const helloWorldHowDoYouDo = "Hello world, how do you do?";
+console.log(helloWorldHowDoYouDo);`
+      }
+    ],
+    async ({ code, expected }) => {
+      const selection = Selection.cursorAt(0, 12);
+      const result = await doExtractVariable(code, selection);
+      expect(result).toBe(expected);
+    }
+  );
+
+  testEach<{ code: Code; expected: Code }>(
+    "should default on 'extracted' for",
+    [
+      {
+        description: "a name that would be bigger than 20 characters",
+        code: `console.log("Hello world, how do you do? -N");`,
+        expected: `const extracted = "Hello world, how do you do? -N";
+console.log(extracted);`
       }
     ],
     async ({ code, expected }) => {

--- a/src/refactorings/extract-variable/extract-variable.variable-name.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.variable-name.test.ts
@@ -1,0 +1,34 @@
+import { Code } from "../../editor/editor";
+import { Selection } from "../../editor/selection";
+import { InMemoryEditor } from "../../editor/adapters/in-memory-editor";
+import { testEach } from "../../tests-helpers";
+
+import { extractVariable } from "./extract-variable";
+
+describe("Extract Variable - Variable name", () => {
+  testEach<{ code: Code; expected: Code }>(
+    "should infer variable name for",
+    [
+      {
+        description: "a string literal",
+        code: `console.log("Hello world!");`,
+        expected: `const helloWorld = "Hello world!";
+console.log(helloWorld);`
+      }
+    ],
+    async ({ code, expected }) => {
+      const selection = Selection.cursorAt(0, 12);
+      const result = await doExtractVariable(code, selection);
+      expect(result).toBe(expected);
+    }
+  );
+
+  async function doExtractVariable(
+    code: Code,
+    selection: Selection
+  ): Promise<Code> {
+    const editor = new InMemoryEditor(code);
+    await extractVariable(code, selection, editor);
+    return editor.code;
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1158,7 +1158,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-change-case@^3.1.0:
+change-case@3.1.0, change-case@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.1.0.tgz#0e611b7edc9952df2e8513b27b42de72647dd17e"
   integrity sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==


### PR DESCRIPTION
Consider the following code:

```js
console.log("Hello World!");
```

If you extracted `"Hello World!"`, you would end up with the following code:

```js
const extracted = "Hello World!";
console.log(extracted);
```

And you'll be renaming the `extracted` symbol. Which is a quick and efficient way to extract the variable.

But now, it'll try to do a bit better. Now, you'll end up with:

```js
const helloWorld = "Hello World!";
console.log(helloWorld);
```

Which would make sense in that case, saving you the trouble of naming it!

Now, predicting the variable name is **hard**. Thus, you'll still be in "renaming mode", so it doesn't really matter if the guess is wrong. If it's correct though, it will certainly save you some more time in your refactoring, and that's the goal!

One last thing: if the inferred name is too long (> 20 characters), it will default on `"extracted"` because it's probably not a good name for your variable.