### PR TITLE
Extract variable destructure member expressions properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **(Breaking)** So… Move Statement Up/Down keybinding was conflicting with VS Code native shortcuts on Mac OS too. It was `⌘ ⇧ ↑/↓`, now it's `Alt + Shift + U / D` for everyone.
 
+#### Extract Variable now destructures member expressions properties
+
+Consider the following code:
+
+```js
+console.log(session.user.address);
+```
+
+Before, extracting `address` would have produced:
+
+```js
+const address = session.user.address;
+console.log(address);
+```
+
+This was fine… But it could be optimized. From our own experience, we always destructure the `address` property after the extraction.
+
+Thus, from now on, extracting `address` will produce:
+
+```js
+const { address } = session.user;
+console.log(address);
+```
+
+Since you end up renaming the symbol, you can provide a different name than `address` and it will work.
+
 ## [2.0.0] - 2019-12-12 - A better shortcut 🛣
 
 ### Changed

--- a/src/ast/transformation.ts
+++ b/src/ast/transformation.ts
@@ -25,7 +25,7 @@ export {
 };
 export { mergeCommentsInto };
 
-function generate(ast: t.File): Code {
+function generate(ast: t.File | t.Node): Code {
   return recast.print(ast).code;
 }
 

--- a/src/refactorings/extract-variable/extract-variable.extractable.test.ts
+++ b/src/refactorings/extract-variable/extract-variable.extractable.test.ts
@@ -287,7 +287,7 @@ console.log({ foo });`
         description: "a spread variable",
         code: `console.log({ ...foo.bar });`,
         selection: Selection.cursorAt(0, 22),
-        expected: `const bar = foo.bar;
+        expected: `const { bar } = foo;
 console.log({ ...bar });`
       },
       {
@@ -315,7 +315,7 @@ console.log({
           "a valid path when cursor is on a part of member expression",
         code: `console.log(path.node.name);`,
         selection: Selection.cursorAt(0, 17),
-        expected: `const node = path.node;
+        expected: `const { node } = path;
 console.log(node.name);`
       },
       {
@@ -529,7 +529,7 @@ if (
 }`,
         selection: Selection.cursorAt(2, 27),
         expected: `function render() {
-  const name = this.props.location.name;
+  const { name } = this.props.location;
   return <div className="text-lg font-weight-bold">
     {name}
   </div>;
@@ -620,7 +620,7 @@ console.log(extracted);`
   node.consequent
 );`,
         selection: Selection.cursorAt(1, 20),
-        expected: `const operator = parentPath.node.operator;
+        expected: `const { operator } = parentPath.node;
 createIfStatement(
   operator,
   parentPath.node.left,
@@ -634,7 +634,7 @@ createIfStatement(
 ) ? "with-loc"
   : "without-loc";`,
         selection: Selection.cursorAt(1, 17),
-        expected: `const length = path.node.loc.length;
+        expected: `const { length } = path.node.loc;
 const type = !!(
   length > 0
 ) ? "with-loc"
@@ -716,7 +716,7 @@ const sayHello = extracted;`
         description: "a for statement",
         code: `for (var i = 0; i < this.items.length; i++) {}`,
         selection: Selection.cursorAt(0, 27),
-        expected: `const items = this.items;
+        expected: `const { items } = this;
 for (var i = 0; i < items.length; i++) {}`
       },
       {

--- a/src/refactorings/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract-variable/extract-variable.ts
@@ -260,10 +260,17 @@ class Occurrence {
   }
 
   toVariableDeclaration(code: Code): Code {
-    const extractedCode = ast.isJSXText(this.path.node) ? `"${code}"` : code;
-    return `const ${this.variable.name} = ${extractedCode};\n${
-      this.indentation
-    }`;
+    const extractedCode = ast.isJSXText(this.path.node)
+      ? `"${code}"`
+      : ast.isMemberExpression(this.path.node) && !this.path.node.computed
+      ? ast.generate(this.path.node.object)
+      : code;
+    const name =
+      ast.isMemberExpression(this.path.node) && !this.path.node.computed
+        ? `{ ${this.variable.name} }`
+        : this.variable.name;
+
+    return `const ${name} = ${extractedCode};\n${this.indentation}`;
   }
 
   private getIndentationLevel(): IndentationLevel {


### PR DESCRIPTION
Consider the following code:

```js
console.log(session.user.address);
```

Before, extracting `address` would have produced:

```js
const address = session.user.address;
console.log(address);
```

This was fine… But it could be optimized. From our own experience, we always destructure the `address` property after the extraction.

Thus, from now on, extracting `address` will produce:

```js
const { address } = session.user;
console.log(address);
```

Since you end up renaming the symbol, you can provide a different name than `address` and it will work.