### PR TITLE
Refactor idea and proof of concept: "Wrap (expression) in function call"

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "jscodeshift": "0.6.4",
     "pluralize": "8.0.0",
     "react-codemod": "5.1.1",
-    "recast": "0.18.1"
+    "recast": "0.19.1"
   },
   "activationEvents": [
     "onCommand:abracadabra.addBracesToArrowFunction",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "onCommand:abracadabra.simplifyTernary",
     "onCommand:abracadabra.splitDeclarationAndInitialization",
     "onCommand:abracadabra.splitIfStatement",
+    "onCommand:abracadabra.wrapInFunctionCall",
     "onLanguage:javascript",
     "onLanguage:javascriptreact",
     "onLanguage:typescript",
@@ -279,6 +280,11 @@
       {
         "command": "abracadabra.splitIfStatement",
         "title": "Split If Statement",
+        "category": "Abracadabra"
+      },
+      {
+        "command": "abracadabra.wrapInFunctionCall",
+        "title": "Wrap In Function Call",
         "category": "Abracadabra"
       }
     ],
@@ -805,6 +811,22 @@
         },
         {
           "command": "abracadabra.splitIfStatement",
+          "when": "editorLangId == typescriptreact"
+        },
+        {
+          "command": "abracadabra.wrapInFunctionCall",
+          "when": "editorLangId == javascript"
+        },
+        {
+          "command": "abracadabra.wrapInFunctionCall",
+          "when": "editorLangId == javascriptreact"
+        },
+        {
+          "command": "abracadabra.wrapInFunctionCall",
+          "when": "editorLangId == typescript"
+        },
+        {
+          "command": "abracadabra.wrapInFunctionCall",
           "when": "editorLangId == typescriptreact"
         }
       ]

--- a/src/editor/adapters/in-memory-editor.ts
+++ b/src/editor/adapters/in-memory-editor.ts
@@ -122,6 +122,10 @@ class InMemoryEditor implements Editor {
     return Promise.resolve();
   }
 
+  select(_selection: Selection) {
+    return Promise.resolve();
+  }
+
   private setCodeMatrix(code: Code) {
     this.codeMatrix = code
       .split(LINE_SEPARATOR)

--- a/src/editor/adapters/vscode-editor.ts
+++ b/src/editor/adapters/vscode-editor.ts
@@ -103,6 +103,11 @@ class VSCodeEditor implements Editor {
     this.editor.selection = toVSCodeCursor(position);
     return Promise.resolve();
   }
+
+  select(selection: Selection) {
+    this.editor.selection = selectionToVSCodeSelection(selection);
+    return Promise.resolve();
+  }
 }
 
 function createSelectionFromVSCode(
@@ -118,6 +123,13 @@ function toVSCodeCursor(position: Position): vscode.Selection {
   return new vscode.Selection(
     toVSCodePosition(position),
     toVSCodePosition(position)
+  );
+}
+
+function selectionToVSCodeSelection(selection: Selection): vscode.Selection {
+  return new vscode.Selection(
+    toVSCodePosition(selection.start),
+    toVSCodePosition(selection.end)
   );
 }
 

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -23,6 +23,7 @@ interface Editor {
   showError(reason: ErrorReason): Promise<void>;
   askUser<T>(choices: Choice<T>[]): Promise<Choice<T> | undefined>;
   moveCursorTo(position: Position): Promise<void>;
+  select(selection: Selection): Promise<void>;
 }
 
 type Modification = {

--- a/src/editor/error-reason.ts
+++ b/src/editor/error-reason.ts
@@ -1,6 +1,7 @@
 export { ErrorReason, toString };
 
 enum ErrorReason {
+  DidNotFindExpressionToWrap,
   DidNotFindLetToConvertToConst,
   DidNotFindSwitchToConvert,
   DidNotFindJsxAttributeToAddBracesTo,
@@ -45,6 +46,9 @@ enum ErrorReason {
 
 function toString(reason: ErrorReason): string {
   switch (reason) {
+    case ErrorReason.DidNotFindExpressionToWrap:
+      return didNotFind("an expression to wrap");
+
     case ErrorReason.DidNotFindLetToConvertToConst:
       return didNotFind(
         "a variable declared as let that could be converted to const"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ import replaceBinaryWithAssignment from "./refactorings/replace-binary-with-assi
 import splitDeclarationAndInitialization from "./refactorings/split-declaration-and-initialization";
 import splitIfStatement from "./refactorings/split-if-statement";
 import simplifyTernary from "./refactorings/simplify-ternary";
+import wrapInFunctionCall from "./refactorings/wrap-in-function-call";
 
 const TS_LANGUAGES = ["typescript", "typescriptreact"];
 const REACT_LANGUAGES = ["javascriptreact", "typescriptreact"];
@@ -84,7 +85,8 @@ export function activate(context: vscode.ExtensionContext) {
     replaceBinaryWithAssignment,
     simplifyTernary,
     splitDeclarationAndInitialization,
-    splitIfStatement
+    splitIfStatement,
+    wrapInFunctionCall
   ].forEach(({ command }) =>
     context.subscriptions.push(
       vscode.commands.registerCommand(
@@ -143,7 +145,8 @@ export function activate(context: vscode.ExtensionContext) {
         replaceBinaryWithAssignment,
         simplifyTernary,
         splitDeclarationAndInitialization,
-        splitIfStatement
+        splitIfStatement,
+        wrapInFunctionCall
       ]),
       {
         providedCodeActionKinds: [vscode.CodeActionKind.RefactorRewrite]

--- a/src/refactorings/wrap-in-function-call/index.ts
+++ b/src/refactorings/wrap-in-function-call/index.ts
@@ -1,0 +1,20 @@
+import {
+  wrapInFunctionCall,
+  createVisitor
+} from "./wrap-in-function-call";
+
+import { RefactoringWithActionProvider } from "../../types";
+
+const config: RefactoringWithActionProvider = {
+  command: {
+    key: "wrapInFunctionCall",
+    operation: wrapInFunctionCall,
+    title: "Wrap In Function Call"
+  },
+  actionProvider: {
+    message: "Wrap in function call",
+    createVisitor
+  }
+};
+
+export default config;

--- a/src/refactorings/wrap-in-function-call/wrap-in-function-call.test.ts
+++ b/src/refactorings/wrap-in-function-call/wrap-in-function-call.test.ts
@@ -45,6 +45,11 @@ describe("Wrap In Function Call", () => {
         code: 'const a = window.confirm("are you sure?");',
         expected: 'const a = wrapped(window.confirm("are you sure?"));',
         selection: Selection.cursorAt(0, 17)
+      },
+      {
+        description: "call expression with generic",
+        code: 'const a = identity<string>("foo");',
+        expected: 'const a = wrapped(identity<string>("foo"));'
       }
     ],
     async ({ code, selection = Selection.cursorAt(0, 10), expected }) => {

--- a/src/refactorings/wrap-in-function-call/wrap-in-function-call.test.ts
+++ b/src/refactorings/wrap-in-function-call/wrap-in-function-call.test.ts
@@ -1,0 +1,77 @@
+import { Editor, ErrorReason, Code } from "../../editor/editor";
+import { Selection } from "../../editor/selection";
+import { InMemoryEditor } from "../../editor/adapters/in-memory-editor";
+import { testEach } from "../../tests-helpers";
+
+import { wrapInFunctionCall } from "./wrap-in-function-call";
+
+describe("Wrap In Function Call", () => {
+  let showErrorMessage: Editor["showError"];
+
+  beforeEach(() => {
+    showErrorMessage = jest.fn();
+  });
+
+  testEach<{ code: Code; selection?: Selection; expected: Code }>(
+    "should wrap in function call",
+    [
+      {
+        description: "primitive",
+        code: 'const a = "foo";',
+        expected: 'const a = wrapped("foo");'
+      },
+      {
+        description: "object",
+        code: 'const a = { foo: "bar" };',
+        expected: `const a = wrapped({
+  foo: "bar"
+});`
+      },
+      {
+        description: "call expression",
+        code: 'const a = fn({ foo: "bar" });',
+        expected: 'const a = wrapped(fn({ foo: "bar" }));'
+      },
+      {
+        description: "call expression (method with object selected)",
+        code: 'const a = window.confirm("are you sure?");',
+        // TODO: not sure about this one
+        expected: 'const a = wrapped(window).confirm("are you sure?");'
+        // or this?
+        // expected: 'const a = wrapped(window.confirm("are you sure?"));'
+      },
+      {
+        description: "call expression (method with member selected)",
+        code: 'const a = window.confirm("are you sure?");',
+        expected: 'const a = wrapped(window.confirm("are you sure?"));',
+        selection: Selection.cursorAt(0, 17)
+      }
+    ],
+    async ({ code, selection = Selection.cursorAt(0, 10), expected }) => {
+      const result = await doWrapInFunctionCall(code, selection);
+
+      expect(result).toBe(expected);
+    }
+  );
+
+  it("should show an error message if refactoring can't be made", async () => {
+    const code = `// This is a comment, can't be refactored`;
+    const selection = Selection.cursorAt(0, 0);
+
+    await doWrapInFunctionCall(code, selection);
+
+    expect(showErrorMessage).toBeCalledWith(
+      ErrorReason.DidNotFindExpressionToWrap
+    );
+  });
+
+  async function doWrapInFunctionCall(
+    code: Code,
+    selection: Selection
+  ): Promise<Code> {
+    const editor = new InMemoryEditor(code);
+    editor.showError = showErrorMessage;
+    await wrapInFunctionCall(code, selection, editor);
+    return editor.code;
+  }
+});

--- a/src/refactorings/wrap-in-function-call/wrap-in-function-call.ts
+++ b/src/refactorings/wrap-in-function-call/wrap-in-function-call.ts
@@ -1,0 +1,105 @@
+// TODO: why isn't action appearing?
+
+import { Editor, Code, ErrorReason } from "../../editor/editor";
+import { Selection } from "../../editor/selection";
+import * as t from "../../ast";
+
+export { wrapInFunctionCall, createVisitor };
+
+async function wrapInFunctionCall(
+  code: Code,
+  selection: Selection,
+  editor: Editor
+) {
+  const updatedCode = updateCode(t.parse(code), selection);
+
+  if (!updatedCode.hasCodeChanged) {
+    editor.showError(ErrorReason.DidNotFindExpressionToWrap);
+    return;
+  }
+
+  await editor.write(updatedCode.code);
+
+  if (updatedCode.newSelection === undefined) {
+    throw new Error("Expected selection to be defined.");
+  }
+
+  editor.select(updatedCode.newSelection);
+}
+
+function updateCode(ast: t.AST, selection: Selection) {
+  let newSelection: Selection | undefined;
+
+  const calleeIdentifierName = "wrapped";
+
+  const result = t.transformAST(
+    ast,
+    createVisitor(selection, path => {
+      const { node } = path;
+
+      if (!t.isSelectableNode(node)) {
+        throw new Error("Expected node to be selectable.");
+      }
+
+      // Select the function callee
+      newSelection = Selection.fromAST({
+        start: node.loc.start,
+        end: {
+          ...node.loc.start,
+          column: node.loc.start.column + calleeIdentifierName.length
+        }
+      });
+
+      path.replaceWith(
+        t.callExpression(t.identifier(calleeIdentifierName), [node])
+      );
+
+      path.stop();
+    })
+  );
+
+  return {
+    ...result,
+    newSelection
+  };
+}
+
+function createVisitor(
+  selection: Selection,
+  onMatch: (path: t.NodePath<t.Expression>) => void
+): t.Visitor {
+  return {
+    Expression(path) {
+      if (!selection.isInsidePath(path)) return;
+
+      // Since we visit nodes from parent to children, first check
+      // if a child would match the selection closer.
+      if (hasChildWhichMatchesSelection(path, selection)) return;
+
+      onMatch(path);
+    }
+  };
+}
+
+function hasChildWhichMatchesSelection(
+  path: t.NodePath,
+  selection: Selection
+): boolean {
+  let result = false;
+
+  path.traverse({
+    Expression(childPath) {
+      if (!selection.isInsidePath(childPath)) return;
+      if (
+        t.isCallExpression(childPath.parent) &&
+        childPath.parent.callee === childPath.node
+      )
+        return;
+
+      result = true;
+      childPath.stop();
+    }
+  });
+
+  return result;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1639,10 +1639,10 @@ ast-types@0.12.1:
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.12.1.tgz#55d3737a8a68e1ccde131067005ce7ee3dd42b99"
   integrity sha512-H2izJAyT2xwew4TxShpmxe6f9R5hHgJQy1QloLiUC2yrJMtyraBWNJL7903rpeCY9keNUipORR/zIUC2XcYKng==
 
-ast-types@0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.1.tgz#9461428a270c5a27fda44b738dd3bab2e9353003"
-  integrity sha512-b+EeK0WlzrSmpMw5jktWvQGxblpWnvMrV+vOp69RLjzGiHwWV0vgq75DPKtUjppKni3yWwSW8WLGV3Ch/XIWcQ==
+ast-types@0.13.3:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.3.tgz#50da3f28d17bdbc7969a3a2d83a0e4a72ae755a7"
+  integrity sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -6580,12 +6580,12 @@ recast@0.17.2:
     private "~0.1.5"
     source-map "~0.6.1"
 
-recast@0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.18.1.tgz#dd1788cfa403be8be06a10f201317f881adc602b"
-  integrity sha512-Ri42yIOwHetqKgEhQSS4N1B9wSLn+eYcyLoQfuSpvd661Jty1Q3P0FXkzjIQ9XxTN+3+kRu1JFXbRmUCUmde5Q==
+recast@0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.19.1.tgz#555f3612a5a10c9f44b9a923875c51ff775de6c8"
+  integrity sha512-8FCjrBxjeEU2O6I+2hyHyBFH1siJbMBLwIRvVr1T3FD2cL754sOaJDsJ/8h3xYltasbJ8jqWRIhMuDGBSiSbjw==
   dependencies:
-    ast-types "0.13.1"
+    ast-types "0.13.3"
     esprima "~4.0.0"
     private "^0.1.8"
     source-map "~0.6.1"


### PR DESCRIPTION
I find myself constantly needing to wrap an expression in a function call, so it would be useful to have a refactor for this. This is how I was doing it before, manually:

![Screen Recording 2020-06-29 at 17 49 21](https://user-images.githubusercontent.com/921609/86034220-13b54780-ba32-11ea-8826-b7191978b60a.gif)

And this is with the new refactoring command:

![Screen Recording 2020-06-29 at 17 49 49](https://user-images.githubusercontent.com/921609/86034227-1748ce80-ba32-11ea-92a2-ae41798db428.gif)

Note I couldn't get the code action to appear. It seemed to be because of this line: https://github.com/nicoespeon/abracadabra/blob/878598a530680c3706037170973c9fc416f15b0a/src/action-providers.ts#L100

`visitorNode` was resolving to `undefined`. This is because I'm traversing the AST for `Expression`, but no nodes have this type directly—it's just a form of grouping, IIUC.

I'm aware that this refactor creates temporarily broken code, because there will most likely be no function named `wrapped`. This is why I've made the refactor immediately select the callee, so it can be replaced, with the help of VS Code auto completion.

I've added some more use cases to the tests.

WDYT? Maybe this isn't something that should live in Abracadabra, but your feedback would be appreciated very much. I've learnt so much from playing with this extension! ❤️ 