### PR TITLE
Extract variable/fix occurrences scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ It will convert the string into a template literal accordingly. It doesn't work 
 
 ### Fixed
 
+- "Extract Variable" now resolves the earliest common ancestor of multiple occurrences that wouldn't be in the same scope. That means there's now less cases where an extraction would be invalid!
+
 - Update the Quick Fixes labels to put "✨" at the end. This allows you to use your keyboard to select a Quick Fix, as it's standard OS behavior. Thanks @OliverJAsh for reporting this accessibility issue!
 
 ## [4.4.0] - 2020-06-13 - Let It Be 🌸

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Update the Quick Fixes labels to put "✨" at the end. This allows you to use your keyboard to select a Quick Fix, as it's standard OS behavior. Thanks @OliverJAsh for reporting this accessibility issue!
-
 ### Added
 
 - "Extract Variable" now extracts substring if that's what you selected!
@@ -18,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 It will convert the string into a template literal accordingly. It doesn't work with multi-lines template literals yet, but it's already very convenient!
 
 ![][demo-extract-substring]
+
+### Fixed
+
+- Update the Quick Fixes labels to put "✨" at the end. This allows you to use your keyboard to select a Quick Fix, as it's standard OS behavior. Thanks @OliverJAsh for reporting this accessibility issue!
 
 ## [4.4.0] - 2020-06-13 - Let It Be 🌸
 
@@ -619,7 +619,7 @@ Consider the following code:
 
 ```js
 const { userId } = session;
-messages.map(message => ({ userId }));
+messages.map((message) => ({ userId }));
 ```
 
 If you tried to inline `userId`, it wouldn't work because destructured object patterns were not supported.
@@ -627,7 +627,7 @@ If you tried to inline `userId`, it wouldn't work because destructured object pa
 Now it would work as expected:
 
 ```js
-messages.map(message => ({ userId: session.userId }));
+messages.map((message) => ({ userId: session.userId }));
 ```
 
 Thanks to @noway for [bringing this one up](https://github.com/nicoespeon/abracadabra/issues/25).

--- a/src/ast/scope.ts
+++ b/src/ast/scope.ts
@@ -3,7 +3,13 @@ import * as t from "@babel/types";
 
 import { areEquivalent } from "./identity";
 
-export { findScopePath, findParentIfPath, getFunctionScopePath, isShadowIn };
+export {
+  findScopePath,
+  findParentIfPath,
+  getFunctionScopePath,
+  isShadowIn,
+  findEarliestCommonAncestorFrom
+};
 
 function findScopePath(path: NodePath<t.Node | null>): NodePath | undefined {
   return path.findParent(
@@ -66,4 +72,12 @@ function isShadowIn(
       )
     );
   }
+}
+
+function findEarliestCommonAncestorFrom(
+  path: NodePath,
+  otherPaths: NodePath[]
+) {
+  // Original type is incorrect, it will return a NodePath or throw
+  return (path.getEarliestCommonAncestorFrom(otherPaths) as any) as NodePath;
 }

--- a/src/editor/selection.ts
+++ b/src/editor/selection.ts
@@ -31,6 +31,10 @@ class Selection {
     return new Selection([line, char], [line, char]);
   }
 
+  static cursorAtPosition(position: Position): Selection {
+    return Selection.fromPositions(position, position);
+  }
+
   static areEqual(
     pathA: ast.SelectablePath,
     pathB: ast.SelectablePath

--- a/src/refactorings/extract/extract-variable/extract-variable.multiple-occurrences.test.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.multiple-occurrences.test.ts
@@ -117,6 +117,36 @@ sendMessage("Hello");`;
     expect(result.code).toBe(expectedCode);
   });
 
+  it("should make the extraction in the scope of all occurrences", async () => {
+    const code = `function sayHello() {
+  if (isValid) {
+    track("said", "Hello");
+  }
+  console.log("Hello");
+}
+
+sendMessage("Hello");`;
+    const selection = Selection.cursorAt(2, 19);
+    askUser = jest.fn(([allOccurrences]) => Promise.resolve(allOccurrences));
+
+    const result = await doExtractVariable(code, selection);
+
+    // TODO: fix indentation
+    const expectedCode = `function sayHello() {
+  const hello = "Hello";
+    if (isValid) {
+    track("said", hello);
+  }
+  console.log(hello);
+}
+
+sendMessage("Hello");`;
+    expect(result.code).toBe(expectedCode);
+  });
+
+  // TODO: occurrences in switch statement => parent should accept code
+  // TODO: position incorrect if deepest ancestor is if statement (inserted between if & block => should be before if)
+
   testEach<{ code: Code; selection?: Selection; expected: Code }>(
     "should extract variables of type",
     [

--- a/src/refactorings/extract/extract-variable/extract-variable.multiple-occurrences.test.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.multiple-occurrences.test.ts
@@ -131,10 +131,9 @@ sendMessage("Hello");`;
 
     const result = await doExtractVariable(code, selection);
 
-    // TODO: fix indentation
     const expectedCode = `function sayHello() {
   const hello = "Hello";
-    if (isValid) {
+  if (isValid) {
     track("said", hello);
   }
   console.log(hello);

--- a/src/refactorings/extract/extract-variable/extract-variable.multiple-occurrences.test.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.multiple-occurrences.test.ts
@@ -143,8 +143,65 @@ sendMessage("Hello");`;
     expect(result.code).toBe(expectedCode);
   });
 
-  // TODO: occurrences in switch statement => parent should accept code
-  // TODO: position incorrect if deepest ancestor is if statement (inserted between if & block => should be before if)
+  it("should make the extraction in the scope of all occurrences (switch statement)", async () => {
+    const code = `function addScore() {
+  switch (tempScore) {
+    case 0:
+      score += 'Love';
+      break;
+    case 1:
+      score += 'Fifteen';
+      break;
+    case 2:
+      score += 'Love';
+      break;
+  }
+}`;
+    const selection = Selection.cursorAt(3, 15);
+    askUser = jest.fn(([allOccurrences]) => Promise.resolve(allOccurrences));
+
+    const result = await doExtractVariable(code, selection);
+
+    const expectedCode = `function addScore() {
+  const love = 'Love';
+  switch (tempScore) {
+    case 0:
+      score += love;
+      break;
+    case 1:
+      score += 'Fifteen';
+      break;
+    case 2:
+      score += love;
+      break;
+  }
+}`;
+    expect(result.code).toBe(expectedCode);
+  });
+
+  it("should make the extraction in the scope of all occurrences (if statement)", async () => {
+    const code = `function sayHello() {
+  if (isMorning) {
+    console.log("hello");
+    console.log("good morning");
+  }
+  console.log("hello");
+}`;
+    const selection = Selection.cursorAt(2, 17);
+    askUser = jest.fn(([allOccurrences]) => Promise.resolve(allOccurrences));
+
+    const result = await doExtractVariable(code, selection);
+
+    const expectedCode = `function sayHello() {
+  const hello = "hello";
+  if (isMorning) {
+    console.log(hello);
+    console.log("good morning");
+  }
+  console.log(hello);
+}`;
+    expect(result.code).toBe(expectedCode);
+  });
 
   testEach<{ code: Code; selection?: Selection; expected: Code }>(
     "should extract variables of type",

--- a/src/refactorings/extract/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.ts
@@ -1,11 +1,5 @@
-import {
-  Editor,
-  Code,
-  ErrorReason,
-  Modification
-} from "../../../editor/editor";
+import { Editor, Code, ErrorReason } from "../../../editor/editor";
 import { Selection } from "../../../editor/selection";
-import { Position } from "../../../editor/position";
 import * as t from "../../../ast";
 
 import { renameSymbol } from "../../rename-symbol/rename-symbol";
@@ -14,6 +8,7 @@ import {
   ReplacementStrategy,
   askReplacementStrategy
 } from "../replacement-strategy";
+import { VariableDeclarationModification } from "./variable-declaration-modification";
 
 export { extractVariable };
 
@@ -56,72 +51,6 @@ async function extractVariable(
 
   // Extracted symbol is located at `selection` => just trigger a rename.
   await renameSymbol(editor);
-}
-
-class VariableDeclarationModification implements Modification {
-  constructor(
-    private value: Code,
-    private selectedOccurrence: Occurrence,
-    private allOccurrences: Occurrence[]
-  ) {}
-
-  get code(): Code {
-    const { name, value } = this.selectedOccurrence.toVariableDeclaration(
-      this.value
-    );
-
-    const indentationLevel = this.selection.start.character;
-    const indentation = this.indentationChar.repeat(indentationLevel);
-
-    return `const ${name} = ${value};\n${indentation}`;
-  }
-
-  get selection(): Selection {
-    const topMostOccurrence = this.allOccurrences.sort(topToBottom)[0];
-    let cursorOnCommonAncestor = Selection.cursorAtPosition(
-      topMostOccurrence.parentScopePosition
-    );
-
-    if (this.allOccurrences.length > 1) {
-      try {
-        const commonAncestor = t.findEarliestCommonAncestorFrom(
-          topMostOccurrence.path,
-          this.allOccurrences.map((occurrence) => occurrence.path)
-        );
-
-        if (t.isSelectableNode(commonAncestor.node)) {
-          cursorOnCommonAncestor = Selection.cursorAtPosition(
-            Position.fromAST(commonAncestor.node.loc.start)
-          );
-        }
-      } catch {
-        // If occurrences don't have a common ancestor, top most occurrence scope is enough.
-        // E.g. declarations at Program root level
-      }
-    }
-
-    return cursorOnCommonAncestor;
-  }
-
-  private get indentationChar(): string {
-    try {
-      const {
-        line: sourceCodeChars
-        // @ts-ignore It's not typed, but it seems recast adds info at runtime.
-      } = this.selectedOccurrence.path.node.loc.lines.infos[
-        this.selectedOccurrence.loc.start.line - 1
-      ];
-
-      return sourceCodeChars[0];
-    } catch (_) {
-      // If it fails at runtime, fallback on a space.
-      return " ";
-    }
-  }
-}
-
-function topToBottom(a: Occurrence, b: Occurrence): number {
-  return a.selection.startsBefore(b.selection) ? -1 : 1;
 }
 
 function findAllOccurrences(code: Code, selection: Selection): AllOccurrences {

--- a/src/refactorings/extract/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.ts
@@ -69,7 +69,9 @@ class VariableDeclarationModification implements Modification {
     const { name, value } = this.selectedOccurrence.toVariableDeclaration(
       this.value
     );
-    const indentation = this.indentationChar.repeat(this.indentationLevel);
+
+    const indentationLevel = this.selection.start.character;
+    const indentation = this.indentationChar.repeat(indentationLevel);
 
     return `const ${name} = ${value};\n${indentation}`;
   }
@@ -116,10 +118,6 @@ class VariableDeclarationModification implements Modification {
     }
   }
 
-  private get indentationLevel(): IndentationLevel {
-    return this.getParentScopePosition(this.selectedOccurrence).character;
-  }
-
   private getParentScopePosition(occurrence: Occurrence): Position {
     const parentPath = t.findScopePath(occurrence.path);
     const parent = parentPath ? parentPath.node : occurrence.path.node;
@@ -128,8 +126,6 @@ class VariableDeclarationModification implements Modification {
     return Position.fromAST(parent.loc.start);
   }
 }
-
-type IndentationLevel = number;
 
 function topToBottom(a: Occurrence, b: Occurrence): number {
   return a.selection.startsBefore(b.selection) ? -1 : 1;

--- a/src/refactorings/extract/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.ts
@@ -5,6 +5,7 @@ import {
   Modification
 } from "../../../editor/editor";
 import { Selection } from "../../../editor/selection";
+import { Position } from "../../../editor/position";
 import * as t from "../../../ast";
 
 import { renameSymbol } from "../../rename-symbol/rename-symbol";
@@ -13,7 +14,6 @@ import {
   ReplacementStrategy,
   askReplacementStrategy
 } from "../replacement-strategy";
-import { Position } from "../../../editor/position";
 
 export { extractVariable };
 
@@ -78,8 +78,9 @@ class VariableDeclarationModification implements Modification {
 
   get selection(): Selection {
     const topMostOccurrence = this.allOccurrences.sort(topToBottom)[0];
-    const position = this.getParentScopePosition(topMostOccurrence);
-    let cursorOnCommonAncestor = Selection.fromPositions(position, position);
+    let cursorOnCommonAncestor = Selection.cursorAtPosition(
+      topMostOccurrence.parentScopePosition
+    );
 
     if (this.allOccurrences.length > 1) {
       try {
@@ -116,14 +117,6 @@ class VariableDeclarationModification implements Modification {
       // If it fails at runtime, fallback on a space.
       return " ";
     }
-  }
-
-  private getParentScopePosition(occurrence: Occurrence): Position {
-    const parentPath = t.findScopePath(occurrence.path);
-    const parent = parentPath ? parentPath.node : occurrence.path.node;
-    if (!parent.loc) return this.selection.start;
-
-    return Position.fromAST(parent.loc.start);
   }
 }
 

--- a/src/refactorings/extract/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.ts
@@ -36,18 +36,16 @@ async function extractVariable(
       : [selectedOccurrence];
   const topMostOccurrence = extractedOccurrences.sort(topToBottom)[0];
 
-  // TODO: encapsulate logic where it makes more sense
-  let commonAncestorCursor = topMostOccurrence.scopeParentCursor;
+  let cursorOnCommonAncestor = topMostOccurrence.cursorOnParentScope;
   if (extractedOccurrences.length > 1) {
     try {
       const commonAncestor = (topMostOccurrence.path.getEarliestCommonAncestorFrom(
         extractedOccurrences.map((occurrence) => occurrence.path)
         //TODO: fix types & encapsulate logic into AST
       ) as any) as t.SelectablePath;
-      //TODO: rename & encapsulate logic inside Selection
-      const start = Position.fromAST(commonAncestor.node.loc.start);
-
-      commonAncestorCursor = Selection.cursorAt(start.line, start.character);
+      cursorOnCommonAncestor = Selection.cursorAtPosition(
+        Position.fromAST(commonAncestor.node.loc.start)
+      );
     } catch {
       // If occurrences don't have a common ancestor, top most occurrence scope is enough.
       // E.g. declarations at Program root level
@@ -60,7 +58,7 @@ async function extractVariable(
       // Insert new variable declaration.
       {
         code: selectedOccurrence.toVariableDeclaration(extractedCode),
-        selection: commonAncestorCursor
+        selection: cursorOnCommonAncestor
       },
       // Replace extracted code with new variable.
       ...extractedOccurrences.map((occurrence) => occurrence.modification)

--- a/src/refactorings/extract/extract-variable/occurrence.ts
+++ b/src/refactorings/extract/extract-variable/occurrence.ts
@@ -83,6 +83,14 @@ class Occurrence<T extends t.Node = t.Node> {
     );
   }
 
+  get parentScopePosition(): Position {
+    const parentPath = t.findScopePath(this.path);
+    const parent = parentPath ? parentPath.node : this.path.node;
+    if (!parent.loc) return this.selection.start;
+
+    return Position.fromAST(parent.loc.start);
+  }
+
   toVariableDeclaration(code: Code): { name: Code; value: Code } {
     return {
       name: this.variable.name,

--- a/src/refactorings/extract/extract-variable/occurrence.ts
+++ b/src/refactorings/extract/extract-variable/occurrence.ts
@@ -87,8 +87,8 @@ class Occurrence<T extends t.Node = t.Node> {
     );
   }
 
-  get scopeParentCursor(): Selection {
-    const position = this.getScopeParentPosition();
+  get cursorOnParentScope(): Selection {
+    const position = this.getParentScopePosition();
     return Selection.fromPositions(position, position);
   }
 
@@ -114,10 +114,10 @@ class Occurrence<T extends t.Node = t.Node> {
   }
 
   private get indentationLevel(): IndentationLevel {
-    return this.getScopeParentPosition().character;
+    return this.getParentScopePosition().character;
   }
 
-  private getScopeParentPosition(): Position {
+  private getParentScopePosition(): Position {
     const parentPath = t.findScopePath(this.path);
     const parent = parentPath ? parentPath.node : this.path.node;
     if (!parent.loc) return this.selection.start;

--- a/src/refactorings/extract/extract-variable/occurrence.ts
+++ b/src/refactorings/extract/extract-variable/occurrence.ts
@@ -83,45 +83,11 @@ class Occurrence<T extends t.Node = t.Node> {
     );
   }
 
-  // TODO: move
-  cursorOnCommonAncestor(allOccurrences: Occurrence[]): Selection {
-    const position = this.getParentScopePosition();
-    let cursor = Selection.fromPositions(position, position);
-
-    if (allOccurrences.length > 1) {
-      try {
-        const commonAncestor = t.findEarliestCommonAncestorFrom(
-          this.path,
-          allOccurrences.map((occurrence) => occurrence.path)
-        );
-
-        if (t.isSelectableNode(commonAncestor.node)) {
-          cursor = Selection.cursorAtPosition(
-            Position.fromAST(commonAncestor.node.loc.start)
-          );
-        }
-      } catch {
-        // If occurrences don't have a common ancestor, top most occurrence scope is enough.
-        // E.g. declarations at Program root level
-      }
-    }
-
-    return cursor;
-  }
-
   toVariableDeclaration(code: Code): { name: Code; value: Code } {
     return {
       name: this.variable.name,
       value: t.isJSXText(this.path.node) ? `"${code}"` : code
     };
-  }
-
-  private getParentScopePosition(): Position {
-    const parentPath = t.findScopePath(this.path);
-    const parent = parentPath ? parentPath.node : this.path.node;
-    if (!parent.loc) return this.selection.start;
-
-    return Position.fromAST(parent.loc.start);
   }
 }
 

--- a/src/refactorings/extract/extract-variable/occurrence.ts
+++ b/src/refactorings/extract/extract-variable/occurrence.ts
@@ -93,13 +93,16 @@ class Occurrence<T extends t.Node = t.Node> {
 
     if (allOccurrences.length > 1) {
       try {
-        const commonAncestor = (this.path.getEarliestCommonAncestorFrom(
+        const commonAncestor = t.findEarliestCommonAncestorFrom(
+          this.path,
           allOccurrences.map((occurrence) => occurrence.path)
-          //TODO: fix types & encapsulate logic into AST
-        ) as any) as t.SelectablePath;
-        cursor = Selection.cursorAtPosition(
-          Position.fromAST(commonAncestor.node.loc.start)
         );
+
+        if (t.isSelectableNode(commonAncestor.node)) {
+          cursor = Selection.cursorAtPosition(
+            Position.fromAST(commonAncestor.node.loc.start)
+          );
+        }
       } catch {
         // If occurrences don't have a common ancestor, top most occurrence scope is enough.
         // E.g. declarations at Program root level

--- a/src/refactorings/extract/extract-variable/variable-declaration-modification.ts
+++ b/src/refactorings/extract/extract-variable/variable-declaration-modification.ts
@@ -32,20 +32,15 @@ class VariableDeclarationModification implements Modification {
     );
 
     if (this.allOccurrences.length > 1) {
-      try {
-        const commonAncestor = t.findEarliestCommonAncestorFrom(
-          topMostOccurrence.path,
-          this.allOccurrences.map((occurrence) => occurrence.path)
-        );
+      const commonAncestor = t.findCommonAncestorToDeclareVariable(
+        topMostOccurrence.path,
+        this.allOccurrences.map((occurrence) => occurrence.path)
+      );
 
-        if (t.isSelectableNode(commonAncestor.node)) {
-          cursorOnCommonAncestor = Selection.cursorAtPosition(
-            Position.fromAST(commonAncestor.node.loc.start)
-          );
-        }
-      } catch {
-        // If occurrences don't have a common ancestor, top most occurrence scope is enough.
-        // E.g. declarations at Program root level
+      if (commonAncestor) {
+        cursorOnCommonAncestor = Selection.cursorAtPosition(
+          Position.fromAST(commonAncestor.node.loc.start)
+        );
       }
     }
 

--- a/src/refactorings/extract/extract-variable/variable-declaration-modification.ts
+++ b/src/refactorings/extract/extract-variable/variable-declaration-modification.ts
@@ -1,0 +1,74 @@
+import { Code, Modification } from "../../../editor/editor";
+import { Selection } from "../../../editor/selection";
+import { Position } from "../../../editor/position";
+import * as t from "../../../ast";
+
+import { Occurrence } from "./occurrence";
+
+export { VariableDeclarationModification };
+
+class VariableDeclarationModification implements Modification {
+  constructor(
+    private value: Code,
+    private selectedOccurrence: Occurrence,
+    private allOccurrences: Occurrence[]
+  ) {}
+
+  get code(): Code {
+    const { name, value } = this.selectedOccurrence.toVariableDeclaration(
+      this.value
+    );
+
+    const indentationLevel = this.selection.start.character;
+    const indentation = this.indentationChar.repeat(indentationLevel);
+
+    return `const ${name} = ${value};\n${indentation}`;
+  }
+
+  get selection(): Selection {
+    const topMostOccurrence = this.allOccurrences.sort(topToBottom)[0];
+    let cursorOnCommonAncestor = Selection.cursorAtPosition(
+      topMostOccurrence.parentScopePosition
+    );
+
+    if (this.allOccurrences.length > 1) {
+      try {
+        const commonAncestor = t.findEarliestCommonAncestorFrom(
+          topMostOccurrence.path,
+          this.allOccurrences.map((occurrence) => occurrence.path)
+        );
+
+        if (t.isSelectableNode(commonAncestor.node)) {
+          cursorOnCommonAncestor = Selection.cursorAtPosition(
+            Position.fromAST(commonAncestor.node.loc.start)
+          );
+        }
+      } catch {
+        // If occurrences don't have a common ancestor, top most occurrence scope is enough.
+        // E.g. declarations at Program root level
+      }
+    }
+
+    return cursorOnCommonAncestor;
+  }
+
+  private get indentationChar(): string {
+    try {
+      const {
+        line: sourceCodeChars
+        // @ts-ignore It's not typed, but it seems recast adds info at runtime.
+      } = this.selectedOccurrence.path.node.loc.lines.infos[
+        this.selectedOccurrence.loc.start.line - 1
+      ];
+
+      return sourceCodeChars[0];
+    } catch (_) {
+      // If it fails at runtime, fallback on a space.
+      return " ";
+    }
+  }
+}
+
+function topToBottom(a: Occurrence, b: Occurrence): number {
+  return a.selection.startsBefore(b.selection) ? -1 : 1;
+}


### PR DESCRIPTION
Fixes #97 

Consider:

```js
function brokenScenario() {
  if (isValid) {
    if (item.name == "sulfuras") {
    }
  }

  console.log("sulfuras");
}
```

Trying to extract `"sulfuras"` before:

```js
function brokenScenario() {
  if (isValid) {
    const sulfuras = "sulfuras";
    if (item.name == sulfuras) {
    }
  }

  console.log(sulfuras);
}
```

Trying to do it now:

```js
function brokenScenario() {
  const sulfuras = "sulfuras";
  if (isValid) {
    if (item.name == sulfuras) {
    }
  }

  console.log(sulfuras);
}
```

🎉 