### PR TITLE
[Extract Variable] Ask destructure strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Extracting a member expression used to destructure it by default. But sometimes, it's not convenient. Consider the following code:
+
+```ts
+console.log(a1.length + a2.length);
+```
+
+If you want to extract both `length`, you'll end up with such code:
+
+```ts
+const { length: a1Length } = a1;
+const { length: a2Length } = a2;
+console.log(a1Length + a2Length);
+```
+
+It's a bit verbose. Now, in such case, you'll be prompt whether you want to destructure or not. So you can easily extract variables into this:
+
+```ts
+const a1Length = a1.length;
+const a2Length = a2.length;
+console.log(a1Length + a2Length);
+```
+
 ### Fixed
 
 - Some string literals couldn't be correctly extracted if they matched reserved words like `return` or `class`. This is now fixed!

--- a/src/ast/identity.ts
+++ b/src/ast/identity.ts
@@ -8,7 +8,7 @@ export {
   isVariableDeclarationIdentifier,
   isFunctionCallIdentifier,
   isJSXPartialElement,
-  isPartOfMemberExpression,
+  isPropertyOfMemberExpression,
   isArrayExpressionElement,
   areAllObjectProperties,
   isUndefinedLiteral,
@@ -49,8 +49,12 @@ function isJSXPartialElement(path: NodePath): boolean {
   return t.isJSXOpeningElement(path) || t.isJSXClosingElement(path);
 }
 
-function isPartOfMemberExpression(path: NodePath): boolean {
-  return t.isMemberExpression(path.parent) && t.isIdentifier(path);
+function isPropertyOfMemberExpression(path: NodePath): boolean {
+  return (
+    t.isMemberExpression(path.parent) &&
+    t.isIdentifier(path) &&
+    !areEquivalent(path.node, path.parent.object)
+  );
 }
 
 function isArrayExpressionElement(

--- a/src/refactorings/extract/extract-variable/destructure-strategy.ts
+++ b/src/refactorings/extract/extract-variable/destructure-strategy.ts
@@ -1,0 +1,6 @@
+export { DestructureStrategy };
+
+enum DestructureStrategy {
+  Destructure,
+  Preserve
+}

--- a/src/refactorings/extract/extract-variable/extract-variable.extractable-objects.test.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.extractable-objects.test.ts
@@ -236,4 +236,17 @@ assert.isTrue(
 
     expect(editor.askUser).not.toBeCalled();
   });
+
+  it("should preserve member expression if user says so", async () => {
+    const code = `console.log(foo.bar.b[cursor]az);`;
+    const editor = new InMemoryEditor(code);
+    jest
+      .spyOn(editor, "askUser")
+      .mockImplementation(([, preserve]) => Promise.resolve(preserve));
+
+    await extractVariable(editor);
+
+    expect(editor.code).toBe(`const baz = foo.bar.baz;
+console.log(baz);`);
+  });
 });

--- a/src/refactorings/extract/extract-variable/extract-variable.extractable-objects.test.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.extractable-objects.test.ts
@@ -211,7 +211,7 @@ assert.isTrue(
   it("should ask if user wants to destructure or not", async () => {
     const code = `console.log(foo.bar.b[cursor]az)`;
     const editor = new InMemoryEditor(code);
-    spyOn(editor, "askUser");
+    jest.spyOn(editor, "askUser");
 
     await extractVariable(editor);
 
@@ -230,7 +230,7 @@ assert.isTrue(
   it("should not ask if user wants to destructure if it can't be", async () => {
     const code = `console.log([cursor]"hello")`;
     const editor = new InMemoryEditor(code);
-    spyOn(editor, "askUser");
+    jest.spyOn(editor, "askUser");
 
     await extractVariable(editor);
 

--- a/src/refactorings/extract/extract-variable/extract-variable.extractable-objects.test.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.extractable-objects.test.ts
@@ -4,6 +4,7 @@ import { InMemoryEditor } from "../../../editor/adapters/in-memory-editor";
 import { testEach } from "../../../tests-helpers";
 
 import { extractVariable } from "./extract-variable";
+import { DestructureStrategy } from "./destructure-strategy";
 
 describe("Extract Variable - Objects we can extract", () => {
   testEach<{
@@ -206,4 +207,33 @@ assert.isTrue(
       }
     }
   );
+
+  it("should ask if user wants to destructure or not", async () => {
+    const code = `console.log(foo.bar.b[cursor]az)`;
+    const editor = new InMemoryEditor(code);
+    spyOn(editor, "askUser");
+
+    await extractVariable(editor);
+
+    expect(editor.askUser).toBeCalledWith([
+      {
+        label: "Destructure => `const { baz } = foo.bar`",
+        value: DestructureStrategy.Destructure
+      },
+      {
+        label: "Preserve => `const baz = foo.bar.baz`",
+        value: DestructureStrategy.Preserve
+      }
+    ]);
+  });
+
+  it("should not ask if user wants to destructure if it can't be", async () => {
+    const code = `console.log([cursor]"hello")`;
+    const editor = new InMemoryEditor(code);
+    spyOn(editor, "askUser");
+
+    await extractVariable(editor);
+
+    expect(editor.askUser).not.toBeCalled();
+  });
 });

--- a/src/refactorings/extract/extract-variable/extract-variable.extractable.test.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.extractable.test.ts
@@ -156,6 +156,13 @@ console.log(node.name);`
       },
       {
         description:
+          "a valid path when cursor is on the first parent of the member expression",
+        code: `console.log([cursor]path.node.name);`,
+        expected: `const extracted = path;
+console.log(extracted.node.name);`
+      },
+      {
+        description:
           "a member expression when property name is not in camel case",
         code: `console.log(path.[cursor]some_node.name);`,
         expected: `const { some_node } = path;

--- a/src/refactorings/extract/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.ts
@@ -174,7 +174,7 @@ function isExtractableContext(node: t.Node): boolean {
 
 function isExtractable(path: t.NodePath): boolean {
   return (
-    !t.isPartOfMemberExpression(path) &&
+    !t.isPropertyOfMemberExpression(path) &&
     !t.isClassPropertyIdentifier(path) &&
     !t.isVariableDeclarationIdentifier(path) &&
     !t.isFunctionCallIdentifier(path) &&

--- a/src/refactorings/extract/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.ts
@@ -32,6 +32,8 @@ async function extractVariable(editor: Editor) {
       ? [selectedOccurrence].concat(otherOccurrences)
       : [selectedOccurrence];
 
+  await selectedOccurrence.askUser(editor);
+
   await editor.readThenWrite(
     selectedOccurrence.selection,
     (extractedCode) => [

--- a/src/refactorings/extract/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.ts
@@ -24,11 +24,14 @@ async function extractVariable(editor: Editor) {
     return;
   }
 
-  const choice = await askReplacementStrategy(otherOccurrences, editor);
-  if (choice === ReplacementStrategy.None) return;
+  const replacementStrategy = await askReplacementStrategy(
+    otherOccurrences,
+    editor
+  );
+  if (replacementStrategy === ReplacementStrategy.None) return;
 
   const extractedOccurrences =
-    choice === ReplacementStrategy.AllOccurrences
+    replacementStrategy === ReplacementStrategy.AllOccurrences
       ? [selectedOccurrence].concat(otherOccurrences)
       : [selectedOccurrence];
 

--- a/src/refactorings/extract/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.ts
@@ -35,7 +35,7 @@ async function extractVariable(editor: Editor) {
       ? [selectedOccurrence].concat(otherOccurrences)
       : [selectedOccurrence];
 
-  await selectedOccurrence.askUser(editor);
+  await selectedOccurrence.askModificationDetails(editor);
 
   await editor.readThenWrite(
     selectedOccurrence.selection,

--- a/src/refactorings/extract/extract-variable/occurrence.ts
+++ b/src/refactorings/extract/extract-variable/occurrence.ts
@@ -1,4 +1,4 @@
-import { Code, Modification } from "../../../editor/editor";
+import { Code, Editor, Modification } from "../../../editor/editor";
 import { Selection } from "../../../editor/selection";
 import { Position } from "../../../editor/position";
 import * as t from "../../../ast";
@@ -10,6 +10,7 @@ import {
   ShorthandVariable
 } from "./variable";
 import { Parts } from "./parts";
+import { DestructureStrategy } from "./destructure-strategy";
 
 export { createOccurrence, Occurrence };
 
@@ -97,6 +98,8 @@ class Occurrence<T extends t.Node = t.Node> {
       value: t.isJSXText(this.path.node) ? `"${code}"` : code
     };
   }
+
+  async askUser(_editor: Editor) {}
 }
 
 class ShorthandOccurrence extends Occurrence<t.ObjectProperty> {
@@ -129,6 +132,23 @@ class MemberExpressionOccurrence extends Occurrence<t.MemberExpression> {
       name: `{ ${this.variable.name} }`,
       value: t.generate(this.path.node.object)
     };
+  }
+
+  async askUser(editor: Editor) {
+    await editor.askUser([
+      {
+        label: `Destructure => \`const { ${this.variable.name} } = ${t.generate(
+          this.path.node.object
+        )}\``,
+        value: DestructureStrategy.Destructure
+      },
+      {
+        label: `Preserve => \`const ${this.variable.name} = ${t.generate(
+          this.path.node.object
+        )}.${this.variable.name}\``,
+        value: DestructureStrategy.Preserve
+      }
+    ]);
   }
 }
 

--- a/src/refactorings/extract/extract-variable/occurrence.ts
+++ b/src/refactorings/extract/extract-variable/occurrence.ts
@@ -130,25 +130,25 @@ class MemberExpressionOccurrence extends Occurrence<t.MemberExpression> {
 
     return {
       name: `{ ${this.variable.name} }`,
-      value: t.generate(this.path.node.object)
+      value: this.parentObject
     };
   }
 
   async askUser(editor: Editor) {
     await editor.askUser([
       {
-        label: `Destructure => \`const { ${this.variable.name} } = ${t.generate(
-          this.path.node.object
-        )}\``,
+        label: `Destructure => \`const { ${this.variable.name} } = ${this.parentObject}\``,
         value: DestructureStrategy.Destructure
       },
       {
-        label: `Preserve => \`const ${this.variable.name} = ${t.generate(
-          this.path.node.object
-        )}.${this.variable.name}\``,
+        label: `Preserve => \`const ${this.variable.name} = ${this.parentObject}.${this.variable.name}\``,
         value: DestructureStrategy.Preserve
       }
     ]);
+  }
+
+  private get parentObject(): Code {
+    return t.generate(this.path.node.object);
   }
 }
 


### PR DESCRIPTION
Resolves #161

If a member expression can be destructured, it will now prompt the user to decide whether they want to destructure or preserve it. Default is for destructuring, as current behavior. But it would make it more convenient when destructuring is not needed.

![image](https://user-images.githubusercontent.com/1094774/95792215-fe96b880-0cb0-11eb-9bf5-dd4b09f584bf.png)
