### PR TITLE
fix: "Extract Class" refactoring from class that implements multiple interfaces

### DIFF
--- a/src/refactorings/extract-class/TypescriptClassNode.test.ts
+++ b/src/refactorings/extract-class/TypescriptClassNode.test.ts
@@ -1,0 +1,16 @@
+import { TypescriptClassNode } from "./TypescriptClassNode";
+
+describe(TypescriptClassNode.name, () => {
+  describe(
+    TypescriptClassNode.prototype.createClassNodeWithSameInstanceMembers.name,
+    () => {
+      it("should clone class node without interfaces", () => {
+        const source = "class Source implements ISource, ISource2 {}";
+        const expected = "class Clone {}";
+        const node = TypescriptClassNode.from(source);
+        const nodeClone = node.createClassNodeWithSameInstanceMembers("Clone");
+        expect(nodeClone.serialize()).toBe(expected);
+      });
+    }
+  );
+});

--- a/src/refactorings/extract-class/TypescriptClassNode.ts
+++ b/src/refactorings/extract-class/TypescriptClassNode.ts
@@ -59,10 +59,14 @@ export class TypescriptClassNode implements ClassNode {
     );
     clone.node.getStaticMembers().forEach((field) => field.remove());
     clone.node.getDecorators().forEach((field) => field.remove());
-    clone.node
-      .getImplements()
-      .forEach((_, i) => clone.node.removeImplements(i));
+    clone.removeAllImplements();
     return clone;
+  }
+
+  private removeAllImplements(): void {
+    while (this.node.getImplements().length) {
+      this.node.removeImplements(0);
+    }
   }
 
   serialize(): string {


### PR DESCRIPTION
I found this bug in angular components and just fixed it.