### PR TITLE
Split declaration initialization / Fix TS Annotation Duplication

### DIFF
--- a/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.test.ts
+++ b/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.test.ts
@@ -62,6 +62,13 @@ firstName = "Jane";
 lastName = "Doe";`
       },
       {
+        description: "declarations with type annotations",
+        code: `const firstName: string = "Jane", age: number = 90;`,
+        expected: `let firstName: string, age: number;
+firstName = "Jane";
+age = 90;`
+      },
+      {
         description: "nested declaration, cursor on wrapper",
         code: `const getLastName = () => {
   const lastName = "Doe";

--- a/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.ts
+++ b/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.ts
@@ -33,8 +33,8 @@ function updateCode(ast: t.AST, selection: Selection): t.Transformed {
         ...declarations
           .filter(isDeclarationInitialized)
           .map(function ({ id, init }) {
-            if ("typeAnnotation" in id) {
-              id.typeAnnotation = null;
+            if (id.type == "Identifier" && "typeAnnotation" in id) {
+              id = t.identifier(id.name);
             }
             return t.expressionStatement(t.assignmentExpression("=", id, init));
           })

--- a/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.ts
+++ b/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.ts
@@ -34,7 +34,7 @@ function updateCode(ast: t.AST, selection: Selection): t.Transformed {
           .filter(isDeclarationInitialized)
           .map(function ({ id, init }) {
             if (id.type == "Identifier" && "typeAnnotation" in id) {
-              id = t.identifier(id.name);
+              id = t.identifier(id.name); // new identifier without annotation
             }
             return t.expressionStatement(t.assignmentExpression("=", id, init));
           })

--- a/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.ts
+++ b/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.ts
@@ -32,9 +32,12 @@ function updateCode(ast: t.AST, selection: Selection): t.Transformed {
         ),
         ...declarations
           .filter(isDeclarationInitialized)
-          .map(({ id, init }) =>
-            t.expressionStatement(t.assignmentExpression("=", id, init))
-          )
+          .map(function ({ id, init }) {
+            if ("typeAnnotation" in id) {
+              id.typeAnnotation = null;
+            }
+            return t.expressionStatement(t.assignmentExpression("=", id, init));
+          })
       ]);
     })
   );


### PR DESCRIPTION
Closes #232 

Adds a test to cover split declaration with TS annotation and fixes the duplication issue.

![split-declaration-initialization-ts](https://user-images.githubusercontent.com/53665722/107094724-8b6fff80-67d5-11eb-8471-baeba0f3ee70.gif)

I'm not sure if my implementation is readable. I felt the need to add a comment to clarify why I create a new Identifier.
It's necessary, because if I reassign the `typeAnnotation` property to null, it mutates the Identifier node in the `variableDeclaration` too. I want the annotation to remain in the declaration, so I need to create a new Identifier and modify that.

Feel free to improve the implementation!
