### PR TITLE
Move types & interfaces to existing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extract Variable won't extract type parameter instantiations anymore, because it shouldn't!
 - Split Declaration from Initialization now works fine with destructured assignments.
 
+### Added
+
+- Move to Existing File now works with types and interfaces! So you can move these to an existing source file.
+
 ## [5.2.0] - 2021-04-15 - Poor Unfortunate Types 🦑
 
 ### Fixed

--- a/src/ast/domain.ts
+++ b/src/ast/domain.ts
@@ -13,6 +13,7 @@ export {
   isEmpty,
   replaceWithBodyOf,
   Primitive,
+  TypeDeclaration,
   forEach
 };
 
@@ -105,6 +106,8 @@ type Primitive =
   | t.NumberLiteral
   | t.BooleanLiteral
   | t.BigIntLiteral;
+
+type TypeDeclaration = t.TSTypeAliasDeclaration | t.TSInterfaceDeclaration;
 
 function forEach(
   object: t.Expression,

--- a/src/ast/scope.ts
+++ b/src/ast/scope.ts
@@ -188,13 +188,13 @@ function getReferencedImportDeclarations(
 }
 
 function getTypeReferencedImportDeclarations(
-  typeAliasPath: NodePath<TypeDeclaration>,
+  typePath: NodePath<TypeDeclaration>,
   programPath: NodePath<t.Program>
 ): t.ImportDeclaration[] {
   let result: t.ImportDeclaration[] = [];
 
   const importDeclarations = getImportDeclarations(programPath);
-  typeAliasPath.traverse({
+  typePath.traverse({
     TSTypeReference(path) {
       if (!path.isReferenced()) return;
 
@@ -247,16 +247,16 @@ function hasReferencesDefinedInSameScope(
 }
 
 function hasTypeReferencesDefinedInSameScope(
-  typeAliasPath: NodePath<TypeDeclaration>
+  typePath: NodePath<TypeDeclaration>
 ): boolean {
   let result = false;
 
-  typeAliasPath.traverse({
+  typePath.traverse({
     TSTypeReference(path) {
       if (!path.isReferenced()) return;
       if (!t.isIdentifier(path.node.typeName)) return;
 
-      if (typeAliasPath.scope.hasGlobal(path.node.typeName.name)) {
+      if (typePath.scope.hasGlobal(path.node.typeName.name)) {
         result = true;
         path.stop();
       }

--- a/src/ast/scope.ts
+++ b/src/ast/scope.ts
@@ -18,7 +18,8 @@ export {
   referencesInScope,
   getReferencedImportDeclarations,
   getTypeReferencedImportDeclarations,
-  hasReferencesDefinedInSameScope
+  hasReferencesDefinedInSameScope,
+  hasTypeReferencesDefinedInSameScope
 };
 
 function findScopePath(path: NodePath<t.Node | null>): NodePath | undefined {
@@ -236,6 +237,26 @@ function hasReferencesDefinedInSameScope(
       if (!path.isReferenced()) return;
 
       if (referencesDefinedInSameScope.includes(path.node.name)) {
+        result = true;
+        path.stop();
+      }
+    }
+  });
+
+  return result;
+}
+
+function hasTypeReferencesDefinedInSameScope(
+  typeAliasPath: NodePath<t.TSTypeAliasDeclaration>
+): boolean {
+  let result = false;
+
+  typeAliasPath.traverse({
+    TSTypeReference(path) {
+      if (!path.isReferenced()) return;
+      if (!t.isIdentifier(path.node.typeName)) return;
+
+      if (typeAliasPath.scope.hasGlobal(path.node.typeName.name)) {
         result = true;
         path.stop();
       }

--- a/src/ast/scope.ts
+++ b/src/ast/scope.ts
@@ -188,7 +188,7 @@ function getReferencedImportDeclarations(
 }
 
 function getTypeReferencedImportDeclarations(
-  typeAliasPath: NodePath<t.TSTypeAliasDeclaration>,
+  typeAliasPath: NodePath<t.TSTypeAliasDeclaration | t.TSInterfaceDeclaration>,
   programPath: NodePath<t.Program>
 ): t.ImportDeclaration[] {
   let result: t.ImportDeclaration[] = [];
@@ -247,7 +247,7 @@ function hasReferencesDefinedInSameScope(
 }
 
 function hasTypeReferencesDefinedInSameScope(
-  typeAliasPath: NodePath<t.TSTypeAliasDeclaration>
+  typeAliasPath: NodePath<t.TSTypeAliasDeclaration | t.TSInterfaceDeclaration>
 ): boolean {
   let result = false;
 

--- a/src/ast/scope.ts
+++ b/src/ast/scope.ts
@@ -1,7 +1,7 @@
 import { NodePath, Binding } from "@babel/traverse";
 import * as t from "@babel/types";
 import { first } from "../array";
-import { getImportDeclarations } from "./domain";
+import { getImportDeclarations, TypeDeclaration } from "./domain";
 
 import { areEquivalent } from "./identity";
 import { isSelectablePath, SelectablePath } from "./selection";
@@ -188,7 +188,7 @@ function getReferencedImportDeclarations(
 }
 
 function getTypeReferencedImportDeclarations(
-  typeAliasPath: NodePath<t.TSTypeAliasDeclaration | t.TSInterfaceDeclaration>,
+  typeAliasPath: NodePath<TypeDeclaration>,
   programPath: NodePath<t.Program>
 ): t.ImportDeclaration[] {
   let result: t.ImportDeclaration[] = [];
@@ -247,7 +247,7 @@ function hasReferencesDefinedInSameScope(
 }
 
 function hasTypeReferencesDefinedInSameScope(
-  typeAliasPath: NodePath<t.TSTypeAliasDeclaration | t.TSInterfaceDeclaration>
+  typeAliasPath: NodePath<TypeDeclaration>
 ): boolean {
   let result = false;
 

--- a/src/ast/transformation.ts
+++ b/src/ast/transformation.ts
@@ -15,6 +15,7 @@ const traverseNode = t.traverse;
 const traversePath = traverse;
 
 export { NodePath, Visitor, Scope } from "@babel/traverse";
+export { RootNodePath, isRootNodePath };
 export {
   generate,
   traverseNode,
@@ -250,4 +251,14 @@ function mergeCommentsInto<T extends t.Node>(
       []
     )
   };
+}
+
+type RootNodePath<T = t.Node> = NodePath<T> & {
+  parentPath: NodePath<t.Program>;
+};
+
+function isRootNodePath<T = t.Node>(
+  path: NodePath<T>
+): path is RootNodePath<T> {
+  return path.parentPath.isProgram();
 }

--- a/src/refactorings/move-to-existing-file/move-to-existing-file.test.ts
+++ b/src/refactorings/move-to-existing-file/move-to-existing-file.test.ts
@@ -145,6 +145,26 @@ const someValue: SomeType = "irrelevant";`,
 const someValue: SomeType = "irrelevant";`,
           otherFile: `export type SomeType = string;`
         }
+      },
+      {
+        description: "a type alias referring to others",
+        setup: {
+          currentFile: `import { OtherType } from "../some-file";
+
+type [cursor]SomeType = OtherType | string;
+
+const someValue: SomeType = "irrelevant";`,
+          otherFile: "",
+          path: new RelativePath("./other-file.ts")
+        },
+        expected: {
+          currentFile: `import { SomeType } from "./other-file";
+import { OtherType } from "../some-file";
+
+const someValue: SomeType = "irrelevant";`,
+          otherFile: `import { OtherType } from "../some-file";
+export type SomeType = OtherType | string;`
+        }
       }
     ],
     async ({ setup, expected }) => {

--- a/src/refactorings/move-to-existing-file/move-to-existing-file.test.ts
+++ b/src/refactorings/move-to-existing-file/move-to-existing-file.test.ts
@@ -221,6 +221,11 @@ function [cursor]doSomething() {
 }
 
 function referencedHere() {}`
+      },
+      {
+        description: "a type alias with references defined in the same file",
+        code: `type [cursor]SomeType = OtherType | string;
+type OtherType = string;`
       }
     ],
     async ({ code }) => {

--- a/src/refactorings/move-to-existing-file/move-to-existing-file.test.ts
+++ b/src/refactorings/move-to-existing-file/move-to-existing-file.test.ts
@@ -185,6 +185,35 @@ let someData: Data;`,
   value: string;
 }`
         }
+      },
+      {
+        description: "an interface referring to others",
+        setup: {
+          currentFile: `import { Value } from "../some-file";
+
+interface [cursor]Data {
+  response: {
+    value: Value;
+  };
+}
+
+let someData: Data;`,
+          otherFile: "",
+          path: new RelativePath("./other-file.ts")
+        },
+        expected: {
+          currentFile: `import { Data } from "./other-file";
+import { Value } from "../some-file";
+
+let someData: Data;`,
+          otherFile: `import { Value } from "../some-file";
+
+export interface Data {
+  response: {
+    value: Value;
+  };
+}`
+        }
       }
     ],
     async ({ setup, expected }) => {
@@ -246,6 +275,14 @@ function referencedHere() {}`
         description: "a type alias with references defined in the same file",
         code: `type [cursor]SomeType = OtherType | string;
 type OtherType = string;`
+      },
+      {
+        description: "an interface with references defined in the same file",
+        code: `interface [cursor]Data {
+  value: Value;
+}
+
+type Value = string;`
       }
     ],
     async ({ code }) => {

--- a/src/refactorings/move-to-existing-file/move-to-existing-file.test.ts
+++ b/src/refactorings/move-to-existing-file/move-to-existing-file.test.ts
@@ -165,6 +165,26 @@ const someValue: SomeType = "irrelevant";`,
           otherFile: `import { OtherType } from "../some-file";
 export type SomeType = OtherType | string;`
         }
+      },
+      {
+        description: "an interface",
+        setup: {
+          currentFile: `interface [cursor]Data {
+  value: string;
+}
+
+let someData: Data;`,
+          otherFile: "",
+          path: new RelativePath("./other-file.ts")
+        },
+        expected: {
+          currentFile: `import { Data } from "./other-file";
+
+let someData: Data;`,
+          otherFile: `export interface Data {
+  value: string;
+}`
+        }
       }
     ],
     async ({ setup, expected }) => {

--- a/src/refactorings/move-to-existing-file/move-to-existing-file.test.ts
+++ b/src/refactorings/move-to-existing-file/move-to-existing-file.test.ts
@@ -129,6 +129,22 @@ export function sayHello() {
   console.log(HELLO, WORLD);
 }`
         }
+      },
+      {
+        description: "a type alias",
+        setup: {
+          currentFile: `type [cursor]SomeType = string;
+
+const someValue: SomeType = "irrelevant";`,
+          otherFile: "",
+          path: new RelativePath("./other-file.ts")
+        },
+        expected: {
+          currentFile: `import { SomeType } from "./other-file";
+
+const someValue: SomeType = "irrelevant";`,
+          otherFile: `export type SomeType = string;`
+        }
       }
     ],
     async ({ setup, expected }) => {

--- a/src/refactorings/move-to-existing-file/move-to-existing-file.ts
+++ b/src/refactorings/move-to-existing-file/move-to-existing-file.ts
@@ -137,6 +137,18 @@ function createVisitor(
         path.parentPath,
         new MovableFunctionDeclaration(path, path.parentPath)
       );
+    },
+    TSTypeAliasDeclaration(path) {
+      if (!path.parentPath.isProgram()) return;
+      if (!path.node.id) return;
+      if (!selection.isInsidePath(path)) return;
+
+      onMatch(
+        path,
+        path.node.id,
+        path.parentPath,
+        new MovableTSTypeAlias(path)
+      );
     }
   };
 }
@@ -200,5 +212,22 @@ class MovableFunctionDeclaration implements MovableNode {
         }
       };
     });
+  }
+}
+
+class MovableTSTypeAlias implements MovableNode {
+  private _value: t.TSTypeAliasDeclaration;
+  readonly hasReferencesThatCantBeImported = false;
+
+  constructor(path: t.NodePath<t.TSTypeAliasDeclaration>) {
+    this._value = path.node;
+  }
+
+  get value(): t.TSTypeAliasDeclaration {
+    return this._value;
+  }
+
+  declarationsToImportFrom(_relativePath: RelativePath): t.ImportDeclaration[] {
+    return [];
   }
 }

--- a/src/refactorings/move-to-existing-file/move-to-existing-file.ts
+++ b/src/refactorings/move-to-existing-file/move-to-existing-file.ts
@@ -121,7 +121,7 @@ function createVisitor(
 ): t.Visitor {
   return {
     FunctionDeclaration(path) {
-      if (!path.parentPath.isProgram()) return;
+      if (!t.isRootNodePath(path)) return;
       if (!path.node.id) return;
       if (!selection.isInsidePath(path)) return;
 
@@ -139,7 +139,7 @@ function createVisitor(
       );
     },
     TSTypeAliasDeclaration(path) {
-      if (!path.parentPath.isProgram()) return;
+      if (!t.isRootNodePath(path)) return;
       if (!path.node.id) return;
       if (!selection.isInsidePath(path)) return;
 
@@ -151,7 +151,7 @@ function createVisitor(
       );
     },
     TSInterfaceDeclaration(path) {
-      if (!path.parentPath.isProgram()) return;
+      if (!t.isRootNodePath(path)) return;
       if (!path.node.id) return;
       if (!selection.isInsidePath(path)) return;
 

--- a/src/refactorings/move-to-existing-file/move-to-existing-file.ts
+++ b/src/refactorings/move-to-existing-file/move-to-existing-file.ts
@@ -147,7 +147,19 @@ function createVisitor(
         path,
         path.node.id,
         path.parentPath,
-        new MovableTSTypeAlias(path, path.parentPath)
+        new MovableTSTypeDeclaration(path, path.parentPath)
+      );
+    },
+    TSInterfaceDeclaration(path) {
+      if (!path.parentPath.isProgram()) return;
+      if (!path.node.id) return;
+      if (!selection.isInsidePath(path)) return;
+
+      onMatch(
+        path,
+        path.node.id,
+        path.parentPath,
+        new MovableTSTypeDeclaration(path, path.parentPath)
       );
     }
   };
@@ -215,13 +227,13 @@ class MovableFunctionDeclaration implements MovableNode {
   }
 }
 
-class MovableTSTypeAlias implements MovableNode {
-  private _value: t.TSTypeAliasDeclaration;
+class MovableTSTypeDeclaration implements MovableNode {
+  private _value: t.TSTypeAliasDeclaration | t.TSInterfaceDeclaration;
   private _hasReferencesThatCantBeImported: boolean;
   private _referencedImportDeclarations: t.ImportDeclaration[];
 
   constructor(
-    path: t.NodePath<t.TSTypeAliasDeclaration>,
+    path: t.NodePath<t.TSTypeAliasDeclaration | t.TSInterfaceDeclaration>,
     programPath: t.NodePath<t.Program>
   ) {
     this._value = path.node;
@@ -234,7 +246,7 @@ class MovableTSTypeAlias implements MovableNode {
     );
   }
 
-  get value(): t.TSTypeAliasDeclaration {
+  get value(): t.TSTypeAliasDeclaration | t.TSInterfaceDeclaration {
     return this._value;
   }
 

--- a/src/refactorings/move-to-existing-file/move-to-existing-file.ts
+++ b/src/refactorings/move-to-existing-file/move-to-existing-file.ts
@@ -217,7 +217,7 @@ class MovableFunctionDeclaration implements MovableNode {
 
 class MovableTSTypeAlias implements MovableNode {
   private _value: t.TSTypeAliasDeclaration;
-  readonly hasReferencesThatCantBeImported = false;
+  private _hasReferencesThatCantBeImported: boolean;
   private _referencedImportDeclarations: t.ImportDeclaration[];
 
   constructor(
@@ -225,6 +225,9 @@ class MovableTSTypeAlias implements MovableNode {
     programPath: t.NodePath<t.Program>
   ) {
     this._value = path.node;
+    this._hasReferencesThatCantBeImported = t.hasTypeReferencesDefinedInSameScope(
+      path
+    );
     this._referencedImportDeclarations = t.getTypeReferencedImportDeclarations(
       path,
       programPath
@@ -233,6 +236,10 @@ class MovableTSTypeAlias implements MovableNode {
 
   get value(): t.TSTypeAliasDeclaration {
     return this._value;
+  }
+
+  get hasReferencesThatCantBeImported(): boolean {
+    return this._hasReferencesThatCantBeImported;
   }
 
   declarationsToImportFrom(relativePath: RelativePath): t.ImportDeclaration[] {

--- a/src/refactorings/move-to-existing-file/move-to-existing-file.ts
+++ b/src/refactorings/move-to-existing-file/move-to-existing-file.ts
@@ -228,12 +228,12 @@ class MovableFunctionDeclaration implements MovableNode {
 }
 
 class MovableTSTypeDeclaration implements MovableNode {
-  private _value: t.TSTypeAliasDeclaration | t.TSInterfaceDeclaration;
+  private _value: t.TypeDeclaration;
   private _hasReferencesThatCantBeImported: boolean;
   private _referencedImportDeclarations: t.ImportDeclaration[];
 
   constructor(
-    path: t.NodePath<t.TSTypeAliasDeclaration | t.TSInterfaceDeclaration>,
+    path: t.NodePath<t.TypeDeclaration>,
     programPath: t.NodePath<t.Program>
   ) {
     this._value = path.node;
@@ -246,7 +246,7 @@ class MovableTSTypeDeclaration implements MovableNode {
     );
   }
 
-  get value(): t.TSTypeAliasDeclaration | t.TSInterfaceDeclaration {
+  get value(): t.TypeDeclaration {
     return this._value;
   }
 

--- a/src/refactorings/move-to-existing-file/move-to-existing-file.ts
+++ b/src/refactorings/move-to-existing-file/move-to-existing-file.ts
@@ -64,19 +64,16 @@ function updateCode(
 
   const updatedCode = t.transformAST(
     ast,
-    createVisitor(
-      selection,
-      (path, importIdentifier, programPath, matchingMovableNode) => {
-        movableNode = matchingMovableNode;
+    createVisitor(selection, (path, importIdentifier, matchingMovableNode) => {
+      movableNode = matchingMovableNode;
 
-        t.addImportDeclaration(
-          programPath,
-          importIdentifier,
-          relativePath.withoutExtension
-        );
-        path.remove();
-      }
-    )
+      t.addImportDeclaration(
+        path.parentPath,
+        importIdentifier,
+        relativePath.withoutExtension
+      );
+      path.remove();
+    })
   );
 
   return {
@@ -113,9 +110,8 @@ function updateOtherFileCode(
 function createVisitor(
   selection: Selection,
   onMatch: (
-    path: t.NodePath,
+    path: t.RootNodePath,
     importIdentifier: t.Identifier,
-    program: t.NodePath<t.Program>,
     movableNode: MovableNode
   ) => void
 ): t.Visitor {
@@ -131,36 +127,21 @@ function createVisitor(
       const bodySelection = Selection.fromAST(body.node.loc);
       if (selection.end.isAfter(bodySelection.start)) return;
 
-      onMatch(
-        path,
-        path.node.id,
-        path.parentPath,
-        new MovableFunctionDeclaration(path, path.parentPath)
-      );
+      onMatch(path, path.node.id, new MovableFunctionDeclaration(path));
     },
     TSTypeAliasDeclaration(path) {
       if (!t.isRootNodePath(path)) return;
       if (!path.node.id) return;
       if (!selection.isInsidePath(path)) return;
 
-      onMatch(
-        path,
-        path.node.id,
-        path.parentPath,
-        new MovableTSTypeDeclaration(path, path.parentPath)
-      );
+      onMatch(path, path.node.id, new MovableTSTypeDeclaration(path));
     },
     TSInterfaceDeclaration(path) {
       if (!t.isRootNodePath(path)) return;
       if (!path.node.id) return;
       if (!selection.isInsidePath(path)) return;
 
-      onMatch(
-        path,
-        path.node.id,
-        path.parentPath,
-        new MovableTSTypeDeclaration(path, path.parentPath)
-      );
+      onMatch(path, path.node.id, new MovableTSTypeDeclaration(path));
     }
   };
 }
@@ -185,20 +166,17 @@ class MovableFunctionDeclaration implements MovableNode {
   private _hasReferencesThatCantBeImported: boolean;
   private _referencedImportDeclarations: t.ImportDeclaration[];
 
-  constructor(
-    path: t.NodePath<t.FunctionDeclaration>,
-    programPath: t.NodePath<t.Program>
-  ) {
+  constructor(path: t.RootNodePath<t.FunctionDeclaration>) {
     // We need to compute these in constructor because the `path` reference
     // will be removed and not accessible later.
     this._value = path.node;
     this._hasReferencesThatCantBeImported = t.hasReferencesDefinedInSameScope(
       path,
-      programPath
+      path.parentPath
     );
     this._referencedImportDeclarations = t.getReferencedImportDeclarations(
       path,
-      programPath
+      path.parentPath
     );
   }
 
@@ -232,17 +210,14 @@ class MovableTSTypeDeclaration implements MovableNode {
   private _hasReferencesThatCantBeImported: boolean;
   private _referencedImportDeclarations: t.ImportDeclaration[];
 
-  constructor(
-    path: t.NodePath<t.TypeDeclaration>,
-    programPath: t.NodePath<t.Program>
-  ) {
+  constructor(path: t.RootNodePath<t.TypeDeclaration>) {
     this._value = path.node;
     this._hasReferencesThatCantBeImported = t.hasTypeReferencesDefinedInSameScope(
       path
     );
     this._referencedImportDeclarations = t.getTypeReferencedImportDeclarations(
       path,
-      programPath
+      path.parentPath
     );
   }
 


### PR DESCRIPTION
Closes https://github.com/nicoespeon/abracadabra/issues/265

Implement "Move to Existing File" for types & interfaces too! It works the same than for functions.

Thanks @ZakMiller for suggesting it 👍 