### PR TITLE
Upgrade babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "deploy:ovsx": "ovsx publish"
   },
   "devDependencies": {
-    "@types/babel__traverse": "7.0.9",
+    "@types/babel__traverse": "7.14.2",
     "@types/chai": "4.2.21",
     "@types/jest": "26.0.24",
     "@types/jscodeshift": "0.6.3",
@@ -87,8 +87,8 @@
   },
   "dependencies": {
     "@babel/parser": "7.15.3",
-    "@babel/traverse": "7.14.0",
-    "@babel/types": "7.9.0",
+    "@babel/traverse": "7.15.0",
+    "@babel/types": "7.15.0",
     "change-case": "4.1.2",
     "jscodeshift": "0.6.4",
     "minimatch": "3.0.4",
@@ -96,6 +96,9 @@
     "react-codemod": "5.1.1",
     "recast": "0.20.4",
     "ts-morph": "^11.0.3"
+  },
+  "resolutions": {
+    "@babel/types": "7.15.0"
   },
   "activationEvents": [
     "onCommand:abracadabra.convertForToForeach",

--- a/src/ast/identity.ts
+++ b/src/ast/identity.ts
@@ -175,9 +175,12 @@ function areSameAssignments(
   );
 }
 
-function areEquivalent(nodeA: t.Node | null, nodeB: t.Node | null): boolean {
-  if (nodeA === null) return false;
-  if (nodeB === null) return false;
+function areEquivalent(
+  nodeA: t.Node | null | undefined,
+  nodeB: t.Node | null | undefined
+): boolean {
+  if (nodeA === null || nodeA === undefined) return false;
+  if (nodeB === null || nodeB === undefined) return false;
 
   if (t.isNullLiteral(nodeA) && t.isNullLiteral(nodeB)) return true;
   if (isUndefinedLiteral(nodeA) && isUndefinedLiteral(nodeB)) return true;

--- a/src/ast/scope.test.ts
+++ b/src/ast/scope.test.ts
@@ -55,7 +55,8 @@ const lambda = (title: string) => title.length > 0;`;
       }
     });
     assert(identifier, "Could not find Identifier from AST");
-    const programScope = identifier.parentPath.parentPath.parent;
+    const programScope = identifier.parentPath?.parentPath?.parent;
+    assert(programScope, "Could not find Program scope from AST");
     const ancestors = await findAncestorAtPosition(
       programScope,
       new Position(1, 16)

--- a/src/ast/scope.ts
+++ b/src/ast/scope.ts
@@ -25,7 +25,7 @@ export {
   hasTypeReferencesDefinedInSameScope
 };
 
-function findScopePath(path: NodePath<t.Node | null>): NodePath | undefined {
+function findScopePath(path: NodePath<t.Node | null>): NodePath | null {
   return path.findParent(
     (parentPath) =>
       t.isExpressionStatement(parentPath) ||
@@ -133,15 +133,16 @@ function getProgramPath(path: NodePath): NodePath {
   return allAncestors[allAncestors.length - 1];
 }
 
-function findAncestorThatCanHaveVariableDeclaration(
-  path: NodePath | null
-): SelectablePath | null {
+function findAncestorThatCanHaveVariableDeclaration<T extends t.Node>(
+  path: NodePath<T> | null
+): SelectablePath<T> | null {
   if (path === null) return null;
   if (isSelectablePath(path)) {
     if (path.isProgram()) return path;
     if (path.isStatement() && !path.isBlockStatement()) return path;
   }
 
+  // @ts-expect-error Not sure how to solve, looks like a typedef issue
   return findAncestorThatCanHaveVariableDeclaration(path.parentPath);
 }
 

--- a/src/ast/selection.ts
+++ b/src/ast/selection.ts
@@ -27,7 +27,7 @@ interface ASTPosition {
   column: number;
 }
 
-type SelectablePath<T = t.Node> = NodePath<Selectable<T>>;
+type SelectablePath<T = t.Node> = NodePath<T> & { node: Selectable<T> };
 type SelectableNode = Selectable<t.Node>;
 type SelectableIdentifier = Selectable<t.Identifier>;
 type SelectableVariableDeclarator = Selectable<t.VariableDeclarator>;

--- a/src/ast/switch.ts
+++ b/src/ast/switch.ts
@@ -9,6 +9,7 @@ function toSwitch(expression: t.Expression): Switch | null {
   if (!VALID_OPERATORS.includes(expression.operator)) return null;
 
   const { left, right } = expression;
+  if (t.isPrivateName(left)) return null;
 
   return t.isIdentifier(left) || t.isMemberExpression(left)
     ? { discriminant: left, test: right }

--- a/src/ast/transformation.ts
+++ b/src/ast/transformation.ts
@@ -260,5 +260,5 @@ type RootNodePath<T = t.Node> = NodePath<T> & {
 function isRootNodePath<T = t.Node>(
   path: NodePath<T>
 ): path is RootNodePath<T> {
-  return path.parentPath.isProgram();
+  return path.parentPath?.isProgram() ?? false;
 }

--- a/src/ast/transformation.ts
+++ b/src/ast/transformation.ts
@@ -216,20 +216,38 @@ function transformCopy<T extends t.Node>(
 // We need to copy {leading,trailing}Comments to preserve them.
 // See: https://github.com/benjamn/recast/issues/572
 function preserveCommentsForRecast(path: NodePath) {
-  // @ts-expect-error Recast does use a `comment` attribute.
-  path.node.comments = path.node.leadingComments;
+  const leadingComments = path.node.leadingComments?.map((comment) => ({
+    ...comment,
+    value: unindent(comment.value)
+  }));
+
+  // @ts-expect-error Recast does use a `comments` attribute.
+  path.node.comments = leadingComments;
 
   if (!path.isBlockStatement() && isLastNode()) {
+    const trailingComments = path.node.trailingComments?.map((comment) => ({
+      ...comment,
+      leading: false,
+      trailing: true,
+      value: unindent(comment.value)
+    }));
+
     // @ts-expect-error Recast does use a `comments` attribute.
     path.node.comments = [
-      ...(path.node.leadingComments || []),
-      ...(path.node.trailingComments || [])
+      ...(leadingComments || []),
+      ...(trailingComments || [])
     ];
   }
 
   function isLastNode(): boolean {
     return path.getAllNextSiblings().length === 0;
   }
+}
+
+function unindent(value: Code): Code {
+  return value
+    .replace(new RegExp("\n  ", "g"), "\n")
+    .replace(new RegExp("\n\t\t", "g"), "\n");
 }
 
 interface Transformed {

--- a/src/refactorings/convert-for-to-foreach/convert-for-to-foreach.ts
+++ b/src/refactorings/convert-for-to-foreach/convert-for-to-foreach.ts
@@ -222,7 +222,14 @@ function getIdentifier(
 }
 
 function getListName(list: List): string {
-  return t.isIdentifier(list) ? list.name : getListName(list.property);
+  if (t.isIdentifier(list)) {
+    return list.name;
+  }
+  if (t.isMemberExpression(list.property)) {
+    return getListName(list.property);
+  }
+
+  return "list";
 }
 
 function replaceListWithItemIn(

--- a/src/refactorings/convert-for-to-foreach/convert-for-to-foreach.ts
+++ b/src/refactorings/convert-for-to-foreach/convert-for-to-foreach.ts
@@ -225,11 +225,11 @@ function getListName(list: List): string {
   if (t.isIdentifier(list)) {
     return list.name;
   }
-  if (t.isMemberExpression(list.property)) {
+  if (t.isMemberExpression(list.property) || t.isIdentifier(list.property)) {
     return getListName(list.property);
   }
 
-  return "list";
+  return "item";
 }
 
 function replaceListWithItemIn(

--- a/src/refactorings/convert-if-else-to-ternary/convert-if-else-to-ternary.ts
+++ b/src/refactorings/convert-if-else-to-ternary/convert-if-else-to-ternary.ts
@@ -94,7 +94,7 @@ class ReturnedTernaryMatcher extends NoopMatcher {
     return createReturnStatement(
       this.path.node.test,
       t.getReturnedStatement(this.path.node.consequent),
-      t.getReturnedStatement(this.path.node.alternate)
+      t.getReturnedStatement(this.path.node.alternate ?? null)
     );
   }
 }
@@ -181,7 +181,9 @@ class AssignedTernaryMatcher extends NoopMatcher {
     const ifAssignedStatement = t.getAssignedStatement(node.consequent);
     if (!ifAssignedStatement) return;
 
-    const elseAssignedStatement = t.getAssignedStatement(node.alternate);
+    const elseAssignedStatement = t.getAssignedStatement(
+      node.alternate ?? null
+    );
     if (!elseAssignedStatement) return;
 
     const ifAssignment = ifAssignedStatement.expression;

--- a/src/refactorings/convert-ternary-to-if-else/convert-ternary-to-if-else.ts
+++ b/src/refactorings/convert-ternary-to-if-else/convert-ternary-to-if-else.ts
@@ -44,13 +44,16 @@ function updateCode(
 
         // AssignmentExpression is contained in an ExpressionStatement
         // => replace parentPath's parent path
-        parentPath.parentPath.replaceWith(
+        const expressionParentPath = parentPath.parentPath;
+        if (!expressionParentPath) return;
+
+        expressionParentPath.replaceWith(
           createIfStatement(selection, node, (expression) =>
             createAssignment(operator, left, expression)
           )
         );
 
-        parentPath.parentPath.stop();
+        expressionParentPath.stop();
       }
 
       if (isAssignedToVariable(path)) {
@@ -111,7 +114,7 @@ function isAssignedToVariable(
 ): path is t.NodePath & { parentPath: t.NodePath<t.VariableDeclarator> } {
   return (
     t.isVariableDeclarator(path.parent) &&
-    t.isVariableDeclaration(path.parentPath.parent)
+    t.isVariableDeclaration(path.parentPath?.parent)
   );
 }
 

--- a/src/refactorings/extract-generic-type/extract-generic-type.ts
+++ b/src/refactorings/extract-generic-type/extract-generic-type.ts
@@ -15,10 +15,8 @@ async function extractGenericType(editor: Editor) {
   const { code, selection } = editor;
   const ast = t.parse(code);
 
-  const {
-    selected: selectedOccurrence,
-    others: otherOccurrences
-  } = findAllOccurrences(ast, selection);
+  const { selected: selectedOccurrence, others: otherOccurrences } =
+    findAllOccurrences(ast, selection);
 
   if (!selectedOccurrence) {
     editor.showError(ErrorReason.DidNotFindExtractableCode);
@@ -104,18 +102,18 @@ function createVisitor(
 function findParentInterfaceDeclaration(
   path: t.SelectablePath<t.TSTypeAnnotation>
 ): InterfaceDeclaration | null {
-  const declaration = path.findParent(t.isTSInterfaceDeclaration) as t.NodePath<
-    t.TSInterfaceDeclaration
-  >;
+  const declaration = path.findParent(
+    t.isTSInterfaceDeclaration
+  ) as t.NodePath<t.TSInterfaceDeclaration>;
   return declaration ? new InterfaceDeclaration(declaration) : null;
 }
 
 function findParentFunctionDeclaration(
   path: t.SelectablePath<t.TSTypeAnnotation>
 ): FunctionDeclaration | null {
-  const declaration = path.findParent(t.isFunctionDeclaration) as t.NodePath<
-    t.FunctionDeclaration
-  >;
+  const declaration = path.findParent(
+    t.isFunctionDeclaration
+  ) as t.NodePath<t.FunctionDeclaration>;
   return declaration ? new FunctionDeclaration(declaration) : null;
 }
 
@@ -254,7 +252,7 @@ class FunctionDeclaration implements Declaration {
   }
 
   get id(): t.Identifier | null {
-    return this.declaration.node.id;
+    return this.declaration.node.id ?? null;
   }
 
   contains(selection: Selection): boolean {

--- a/src/refactorings/extract/extract-variable/extract-variable.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.ts
@@ -104,6 +104,7 @@ function findOtherOccurrences(
     enter(path: t.NodePath) {
       const { node, parentPath } = path;
 
+      if (!parentPath) return;
       if (path.type !== occurrence.path.type) return;
       if (!t.isSelectableNode(node)) return;
       if (!t.isSelectableNode(occurrence.path.node)) return;

--- a/src/refactorings/extract/extract-variable/occurrence.ts
+++ b/src/refactorings/extract/extract-variable/occurrence.ts
@@ -162,6 +162,10 @@ class Occurrence<T extends t.Node = t.Node> {
 
 class ShorthandOccurrence extends Occurrence<t.ObjectProperty> {
   private get keySelection(): Selection {
+    if (!t.isSelectableNode(this.path.node.key)) {
+      return this.selection;
+    }
+
     return Selection.fromAST(this.path.node.key.loc);
   }
 

--- a/src/refactorings/extract/extract-variable/variable.ts
+++ b/src/refactorings/extract/extract-variable/variable.ts
@@ -40,8 +40,8 @@ class Variable<T = t.Node> {
 
   get id(): Code {
     const shouldWrapInBraces =
-      this.path.parentPath.isJSXAttribute() ||
-      (this.path.parentPath.isJSX() &&
+      this.path.parentPath?.isJSXAttribute() ||
+      (this.path.parentPath?.isJSX() &&
         (this.path.isJSXElement() || this.path.isJSXText()));
 
     return shouldWrapInBraces ? `{${this.name}}` : this.name;
@@ -112,10 +112,13 @@ class MemberExpressionVariable extends Variable<
 class ShorthandVariable extends Variable<t.ObjectProperty> {
   constructor(path: t.NodePath<t.ObjectProperty>) {
     super(path);
-    this.tryToSetNameWith(path.node.key.name);
+    if ("name" in path.node.key) {
+      this.tryToSetNameWith(path.node.key.name);
+    }
   }
 
   get isValid(): boolean {
+    if (!("name" in this.path.node.key)) return true;
     return this.isValidName(this.path.node.key.name);
   }
 }

--- a/src/refactorings/inline/inline-function/inline-function.ts
+++ b/src/refactorings/inline/inline-function/inline-function.ts
@@ -194,6 +194,9 @@ function replaceAllIdentifiersWithFunction(
   if (functionBinding) {
     functionBinding.referencePaths
       .map((referencePath) => referencePath.parentPath)
+      .filter(
+        (scopePath): scopePath is t.NodePath<t.Node> => scopePath !== null
+      )
       .forEach((scopePath) => replaceAllIdentifiersInPath(scopePath, node));
   } else {
     // If we don't get the bindings, traverse all the parent nodes.
@@ -233,7 +236,7 @@ function replaceAllIdentifiersInPath(
   }
 
   if (t.isVariableDeclarator(node)) {
-    const identifier = node.init;
+    const identifier = node.init ?? null;
     if (!isMatchingIdentifier(identifier, functionDeclaration)) return;
 
     node.init = t.functionExpression(
@@ -244,7 +247,7 @@ function replaceAllIdentifiersInPath(
   }
 
   if (t.isReturnStatement(node)) {
-    const identifier = node.argument;
+    const identifier = node.argument ?? null;
     if (!isMatchingIdentifier(identifier, functionDeclaration)) return;
 
     node.argument = t.functionExpression(

--- a/src/refactorings/inline/inline-variable/find-inlinable-code.ts
+++ b/src/refactorings/inline/inline-variable/find-inlinable-code.ts
@@ -98,28 +98,16 @@ function getInitName(init: t.Node): string | null {
   if (t.isIdentifier(init)) return init.name;
 
   if (t.isMemberExpression(init)) {
-    const { property, computed } = init;
-
-    const propertyName = t.isNumericLiteral(property)
-      ? `[${property.value}]`
-      : t.isStringLiteral(property)
-      ? `["${property.value}"]`
-      : t.isIdentifier(property)
-      ? computed
-        ? `[${property.name}]`
-        : `.${property.name}`
-      : `.${getInitName(property)}`;
-
     if (
-      "value" in property &&
-      property.value === null &&
-      getInitName(property) === null
+      "value" in init.property &&
+      init.property.value === null &&
+      getInitName(init.property) === null
     ) {
       // We can't resolve property name. Stop here.
       return null;
     }
 
-    return `${getInitName(init.object)}${propertyName}`;
+    return `${getInitName(init.object)}${propertyName(init)}`;
   }
 
   if (t.isObjectProperty(init)) {
@@ -131,6 +119,20 @@ function getInitName(init: t.Node): string | null {
   }
 
   return null;
+}
+
+function propertyName(init: t.MemberExpression) {
+  const { property, computed } = init;
+
+  return t.isNumericLiteral(property)
+    ? `[${property.value}]`
+    : t.isStringLiteral(property)
+    ? `["${property.value}"]`
+    : t.isIdentifier(property)
+    ? computed
+      ? `[${property.name}]`
+      : `.${property.name}`
+    : `.${getInitName(property)}`;
 }
 
 function wrapInTopLevelPattern(

--- a/src/refactorings/inline/inline-variable/find-inlinable-code.ts
+++ b/src/refactorings/inline/inline-variable/find-inlinable-code.ts
@@ -121,18 +121,22 @@ function getInitName(init: t.Node): string | null {
   return null;
 }
 
-function propertyName(init: t.MemberExpression) {
+function propertyName(init: t.MemberExpression): string | null {
   const { property, computed } = init;
 
-  return t.isNumericLiteral(property)
-    ? `[${property.value}]`
-    : t.isStringLiteral(property)
-    ? `["${property.value}"]`
-    : t.isIdentifier(property)
-    ? computed
-      ? `[${property.name}]`
-      : `.${property.name}`
-    : `.${getInitName(property)}`;
+  if (t.isNumericLiteral(property)) {
+    return `[${property.value}]`;
+  }
+
+  if (t.isStringLiteral(property)) {
+    return `["${property.value}"]`;
+  }
+
+  if (t.isIdentifier(property)) {
+    return computed ? `[${property.name}]` : `.${property.name}`;
+  }
+
+  return `.${getInitName(property)}`;
 }
 
 function wrapInTopLevelPattern(

--- a/src/refactorings/inline/inline-variable/find-inlinable-code.ts
+++ b/src/refactorings/inline/inline-variable/find-inlinable-code.ts
@@ -98,16 +98,10 @@ function getInitName(init: t.Node): string | null {
   if (t.isIdentifier(init)) return init.name;
 
   if (t.isMemberExpression(init)) {
-    if (
-      "value" in init.property &&
-      init.property.value === null &&
-      getInitName(init.property) === null
-    ) {
-      // We can't resolve property name. Stop here.
-      return null;
-    }
+    const propertyName = getPropertyName(init);
+    if (!propertyName) return null;
 
-    return `${getInitName(init.object)}${propertyName(init)}`;
+    return `${getInitName(init.object)}${propertyName}`;
   }
 
   if (t.isObjectProperty(init)) {
@@ -121,7 +115,7 @@ function getInitName(init: t.Node): string | null {
   return null;
 }
 
-function propertyName(init: t.MemberExpression): string | null {
+function getPropertyName(init: t.MemberExpression): string | null {
   const { property, computed } = init;
 
   if (t.isNumericLiteral(property)) {

--- a/src/refactorings/inline/inline-variable/find-inlinable-code.ts
+++ b/src/refactorings/inline/inline-variable/find-inlinable-code.ts
@@ -104,13 +104,17 @@ function getInitName(init: t.Node): string | null {
       ? `[${property.value}]`
       : t.isStringLiteral(property)
       ? `["${property.value}"]`
-      : t.isIdentifier(property) && computed
-      ? `[${property.name}]`
+      : t.isIdentifier(property)
+      ? computed
+        ? `[${property.name}]`
+        : `.${property.name}`
       : `.${getInitName(property)}`;
 
-    if (!("value" in property)) return null;
-
-    if (property.value === null && getInitName(property) === null) {
+    if (
+      "value" in property &&
+      property.value === null &&
+      getInitName(property) === null
+    ) {
       // We can't resolve property name. Stop here.
       return null;
     }

--- a/src/refactorings/move-to-existing-file/move-to-existing-file.ts
+++ b/src/refactorings/move-to-existing-file/move-to-existing-file.ts
@@ -31,7 +31,10 @@ async function moveToExistingFile(editor: Editor) {
     relativePath
   );
 
-  if (!movableNode.value) return;
+  if (!movableNode.value) {
+    editor.showError(ErrorReason.DidNotFindCodeToMove);
+    return;
+  }
 
   if (!updatedCode.hasCodeChanged) {
     editor.showError(ErrorReason.DidNotFindCodeToMove);

--- a/src/refactorings/move-to-existing-file/move-to-existing-file.ts
+++ b/src/refactorings/move-to-existing-file/move-to-existing-file.ts
@@ -31,6 +31,8 @@ async function moveToExistingFile(editor: Editor) {
     relativePath
   );
 
+  if (!movableNode.value) return;
+
   if (!updatedCode.hasCodeChanged) {
     editor.showError(ErrorReason.DidNotFindCodeToMove);
     return;
@@ -84,7 +86,7 @@ function updateCode(
 
 function updateOtherFileCode(
   ast: t.AST,
-  movedNode: t.Node,
+  movedNode: t.Declaration,
   declarationsToImport: t.ImportDeclaration[]
 ): t.Transformed {
   return t.transformAST(ast, {
@@ -102,7 +104,9 @@ function updateOtherFileCode(
       const exportedStatement = t.toStatement(
         t.exportNamedDeclaration(movedNode)
       );
-      path.node.body.push(exportedStatement);
+      if (exportedStatement) {
+        path.node.body.push(exportedStatement);
+      }
     }
   });
 }
@@ -147,13 +151,13 @@ function createVisitor(
 }
 
 interface MovableNode {
-  readonly value: t.Node;
+  readonly value: t.Declaration | null;
   readonly hasReferencesThatCantBeImported: boolean;
   declarationsToImportFrom(relativePath: RelativePath): t.ImportDeclaration[];
 }
 
 class MovableEmptyStatement implements MovableNode {
-  readonly value = t.emptyStatement();
+  readonly value = null;
   readonly hasReferencesThatCantBeImported = false;
 
   declarationsToImportFrom(_relativePath: RelativePath): t.ImportDeclaration[] {
@@ -212,9 +216,8 @@ class MovableTSTypeDeclaration implements MovableNode {
 
   constructor(path: t.RootNodePath<t.TypeDeclaration>) {
     this._value = path.node;
-    this._hasReferencesThatCantBeImported = t.hasTypeReferencesDefinedInSameScope(
-      path
-    );
+    this._hasReferencesThatCantBeImported =
+      t.hasTypeReferencesDefinedInSameScope(path);
     this._referencedImportDeclarations = t.getTypeReferencedImportDeclarations(
       path,
       path.parentPath

--- a/src/refactorings/negate-expression/negate-expression.ts
+++ b/src/refactorings/negate-expression/negate-expression.ts
@@ -50,7 +50,7 @@ function findNegatableExpression(
 
 function createVisitor(
   selection: Selection,
-  onMatch: (path: t.NodePath<t.SelectableNode>) => void
+  onMatch: (path: t.SelectablePath) => void
 ): t.Visitor {
   return {
     enter(path) {

--- a/src/refactorings/replace-binary-with-assignment/replace-binary-with-assignment.ts
+++ b/src/refactorings/replace-binary-with-assignment/replace-binary-with-assignment.ts
@@ -50,6 +50,8 @@ function updateCode(ast: t.AST, selection: Selection): t.Transformed {
         ? binaryExpression.left
         : binaryExpression.right;
 
+      if (t.isPrivateName(newRight)) return;
+
       path.replaceWith(
         t.assignmentExpression(`${operator}=`, identifier, newRight)
       );

--- a/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.ts
+++ b/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.ts
@@ -52,9 +52,11 @@ function createVariableDeclarators(leftValue: t.LVal): t.VariableDeclarator[] {
 }
 
 function objectPatternLVals(objectPattern: t.ObjectPattern): t.LVal[] {
-  return objectPattern.properties.map((property) => {
-    return t.isRestElement(property) ? property.argument : property.key;
-  });
+  return objectPattern.properties
+    .map((property) => {
+      return t.isRestElement(property) ? property.argument : property.key;
+    })
+    .filter((lval): lval is t.LVal => t.isLVal(lval));
 }
 
 function createVisitor(

--- a/src/refactorings/toggle-braces/toggle-braces.ts
+++ b/src/refactorings/toggle-braces/toggle-braces.ts
@@ -265,7 +265,7 @@ class RemoveBracesFromArrowFunction implements ToggleBraces {
     const firstValue = blockStatementStatements[0];
 
     if (!t.isReturnStatement(firstValue)) return;
-    if (firstValue.argument === null) return;
+    if (!firstValue.argument) return;
 
     this.path.node.body = firstValue.argument;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,12 +16,12 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
-  integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
+"@babel/code-frame@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
+  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
   dependencies:
-    "@babel/highlight" "^7.12.13"
+    "@babel/highlight" "^7.14.5"
 
 "@babel/compat-data@^7.8.6":
   version "7.8.6"
@@ -53,12 +53,12 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.0.tgz#0f35d663506c43e4f10898fbda0d752ec75494be"
-  integrity sha512-C6u00HbmsrNPug6A+CiNl8rEys7TsdcXwg12BHi2ca5rUfAs3+UwZsuDQSXnc+wCElCXMB8gMaJ3YXDdh8fAlg==
+"@babel/generator@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.15.0.tgz#a7d0c172e0d814974bad5aa77ace543b97917f15"
+  integrity sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==
   dependencies:
-    "@babel/types" "^7.14.0"
+    "@babel/types" "^7.15.0"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -145,14 +145,14 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helper-function-name@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz#93ad656db3c3c2232559fd7b2c3dbdcbe0eb377a"
-  integrity sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==
+"@babel/helper-function-name@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz#89e2c474972f15d8e233b52ee8c480e2cfcd50c4"
+  integrity sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==
   dependencies:
-    "@babel/helper-get-function-arity" "^7.12.13"
-    "@babel/template" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/helper-get-function-arity" "^7.14.5"
+    "@babel/template" "^7.14.5"
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-function-name@^7.8.3":
   version "7.8.3"
@@ -163,12 +163,12 @@
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helper-get-function-arity@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz#bc63451d403a3b3082b97e1d8b3fe5bd4091e583"
-  integrity sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==
+"@babel/helper-get-function-arity@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz#25fbfa579b0937eee1f3b805ece4ce398c431815"
+  integrity sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-get-function-arity@^7.8.3":
   version "7.8.3"
@@ -176,6 +176,13 @@
   integrity sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-hoist-variables@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz#e0dd27c33a78e577d7c8884916a3e7ef1f7c7f8d"
+  integrity sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==
+  dependencies:
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-hoist-variables@^7.8.3":
   version "7.8.3"
@@ -264,12 +271,12 @@
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/helper-split-export-declaration@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz#e9430be00baf3e88b0e13e6f9d4eaf2136372b05"
-  integrity sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==
+"@babel/helper-split-export-declaration@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz#22b23a54ef51c2b7605d851930c1976dd0bc693a"
+  integrity sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==
   dependencies:
-    "@babel/types" "^7.12.13"
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-split-export-declaration@^7.8.3":
   version "7.8.3"
@@ -278,15 +285,15 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-validator-identifier@^7.10.4", "@babel/helper-validator-identifier@^7.9.0":
+"@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
   integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
-"@babel/helper-validator-identifier@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz#d26cad8a47c65286b15df1547319a5d0bcf27288"
-  integrity sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==
+"@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.9":
+  version "7.14.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
+  integrity sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==
 
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
@@ -316,12 +323,12 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/highlight@^7.12.13":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.0.tgz#3197e375711ef6bf834e67d0daec88e4f46113cf"
-  integrity sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==
+"@babel/highlight@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
+  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.14.0"
+    "@babel/helper-validator-identifier" "^7.14.5"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -334,7 +341,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.15.3", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.10.4", "@babel/parser@^7.12.13", "@babel/parser@^7.14.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.8.7", "@babel/parser@^7.9.0":
+"@babel/parser@7.15.3", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.10.4", "@babel/parser@^7.14.5", "@babel/parser@^7.15.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.8.7", "@babel/parser@^7.9.0":
   version "7.15.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.3.tgz#3416d9bea748052cfcb63dbcc27368105b1ed862"
   integrity sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA==
@@ -876,14 +883,14 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/template@^7.12.13":
-  version "7.12.13"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"
-  integrity sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==
+"@babel/template@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
+  integrity sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==
   dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@babel/parser" "^7.12.13"
-    "@babel/types" "^7.12.13"
+    "@babel/code-frame" "^7.14.5"
+    "@babel/parser" "^7.14.5"
+    "@babel/types" "^7.14.5"
 
 "@babel/template@^7.3.3":
   version "7.10.4"
@@ -903,17 +910,18 @@
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
 
-"@babel/traverse@7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.0.tgz#cea0dc8ae7e2b1dec65f512f39f3483e8cc95aef"
-  integrity sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==
+"@babel/traverse@7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.15.0.tgz#4cca838fd1b2a03283c1f38e141f639d60b3fc98"
+  integrity sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==
   dependencies:
-    "@babel/code-frame" "^7.12.13"
-    "@babel/generator" "^7.14.0"
-    "@babel/helper-function-name" "^7.12.13"
-    "@babel/helper-split-export-declaration" "^7.12.13"
-    "@babel/parser" "^7.14.0"
-    "@babel/types" "^7.14.0"
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.15.0"
+    "@babel/helper-function-name" "^7.14.5"
+    "@babel/helper-hoist-variables" "^7.14.5"
+    "@babel/helper-split-export-declaration" "^7.14.5"
+    "@babel/parser" "^7.15.0"
+    "@babel/types" "^7.15.0"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -932,39 +940,12 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@7.9.0", "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.8.7", "@babel/types@^7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.0.tgz#00b064c3df83ad32b2dbf5ff07312b15c7f1efb5"
-  integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
+"@babel/types@7.15.0", "@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.14.5", "@babel/types@^7.15.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.8.7", "@babel/types@^7.9.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.0.tgz#61af11f2286c4e9c69ca8deb5f4375a73c72dcbd"
+  integrity sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.9.0"
-    lodash "^4.17.13"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.4.tgz#369517188352e18219981efd156bfdb199fff1ee"
-  integrity sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.10.4"
-    lodash "^4.17.13"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.12.13", "@babel/types@^7.14.0":
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.0.tgz#3fc3fc74e0cdad878182e5f66cc6bcab1915a802"
-  integrity sha512-O2LVLdcnWplaGxiPBz12d0HcdN8QdxdsWYhz5LSeuukV/5mn2xUUc3gBeU4QBYPJ18g/UToe8F532XJ608prmg==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.14.0"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.3.3":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.0.tgz#2ae6bf1ba9ae8c3c43824e5861269871b206e90d"
-  integrity sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.10.4"
-    lodash "^4.17.19"
+    "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -1268,10 +1249,17 @@
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
 
-"@types/babel__traverse@*", "@types/babel__traverse@7.0.9", "@types/babel__traverse@^7.0.6":
+"@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
   version "7.0.9"
   resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.9.tgz#be82fab304b141c3eee81a4ce3b034d0eba1590a"
   integrity sha512-jEFQ8L1tuvPjOI8lnpaf73oCJe+aoxL6ygqSy6c8LcW98zaC+4mzWuQIRCEvKeCOu+lbqdXcg4Uqmm1S8AP1tw==
+  dependencies:
+    "@babel/types" "^7.3.0"
+
+"@types/babel__traverse@7.14.2":
+  version "7.14.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.14.2.tgz#ffcd470bbb3f8bf30481678fb5502278ca833a43"
+  integrity sha512-K2waXdXBi2302XUdcHcR1jCeU0LL4TD9HRs/gk0N2Xvrht+G/BfJa4QObBQZfhMdxiCpV3COl5Nfq4uKTeTnJA==
   dependencies:
     "@babel/types" "^7.3.0"
 


### PR DESCRIPTION
I finally took the time to upgrade babel from 7.9 to the latest version (7.15), resolving the type conflicts.

A few code changes were required too. I'm glad we have a good test coverage: now I feel confident there's no regression (unless we are missing tests for these).