### PR TITLE
changed path to use path.posix

### DIFF
--- a/src/editor/path.ts
+++ b/src/editor/path.ts
@@ -1,4 +1,5 @@
-import * as path from "path";
+import * as _path from "path";
+const path = _path.posix;
 
 export { Path, AbsolutePath, RelativePath };
 


### PR DESCRIPTION
vscode uses `/` separator in any os
path.posix will use `/` separator in any os
Fixes #376 