### PR TITLE
Prevent "Merge If Statements" from being suggested where it can't execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Finally got "Move to existing file" work on Windows OS, thanks to @sumbatx15
+- Merge If Statements used to appear on patterns it couldn't execute on. Not anymore!
 
 ### Added
 

--- a/src/refactorings/merge-if-statements/merge-if-statements.test.ts
+++ b/src/refactorings/merge-if-statements/merge-if-statements.test.ts
@@ -2,7 +2,7 @@ import { Code, ErrorReason } from "../../editor/editor";
 import { InMemoryEditor } from "../../editor/adapters/in-memory-editor";
 import { testEach } from "../../tests-helpers";
 
-import { mergeIfStatements } from "./merge-if-statements";
+import { canMergeIfStatements, mergeIfStatements } from "./merge-if-statements";
 
 describe("Merge If Statements", () => {
   testEach<{ code: Code; expected: Code }>(
@@ -490,5 +490,26 @@ describe("Merge If Statements", () => {
     expect(editor.showError).toBeCalledWith(
       ErrorReason.DidNotFindIfStatementsToMerge
     );
+  });
+
+  it("should not match a guard clause", async () => {
+    const code = `function toto() {
+  if (isValid || isMorning)[cursor] return
+}`;
+    const editor = new InMemoryEditor(code);
+
+    await expect(canMergeIfStatements).not.toMatchEditor(editor);
+  });
+
+  it("should not match else-if with different returned values", async () => {
+    const code = `function toto() {
+  if (isValid)
+    return 50;
+  else if (isMorning)[cursor]
+    return 100;
+}`;
+    const editor = new InMemoryEditor(code);
+
+    await expect(canMergeIfStatements).not.toMatchEditor(editor);
   });
 });

--- a/src/refactorings/merge-if-statements/merge-if-statements.test.ts
+++ b/src/refactorings/merge-if-statements/merge-if-statements.test.ts
@@ -4,7 +4,7 @@ import { testEach } from "../../tests-helpers";
 
 import { mergeIfStatements } from "./merge-if-statements";
 
-describe("Split If Statement", () => {
+describe("Merge If Statements", () => {
   testEach<{ code: Code; expected: Code }>(
     "should merge if statements",
     [

--- a/src/refactorings/merge-if-statements/merge-if-statements.ts
+++ b/src/refactorings/merge-if-statements/merge-if-statements.ts
@@ -92,6 +92,16 @@ abstract class MergeIfStatements<T = t.IfStatement> {
   protected abstract merge(): void;
 }
 
+class NoMerge extends MergeIfStatements {
+  get canMerge(): boolean {
+    return false;
+  }
+
+  merge() {
+    /** Do nothing */
+  }
+}
+
 class MergeConsequentWithPreviousSibling extends MergeIfStatements {
   static canExecuteOn(ifStatement: t.NodePath<t.IfStatement>): boolean {
     const previousSibling = t.getPreviousSibling(ifStatement);

--- a/src/refactorings/merge-if-statements/merge-if-statements.ts
+++ b/src/refactorings/merge-if-statements/merge-if-statements.ts
@@ -80,7 +80,7 @@ abstract class MergeIfStatements<T = t.IfStatement> {
   }
 
   get canExecute(): boolean {
-    return this.canMerge ?? Boolean(this.next?.canExecute);
+    return this.canMerge || Boolean(this.next?.canExecute);
   }
 
   execute(): void {

--- a/src/refactorings/merge-if-statements/merge-if-statements.ts
+++ b/src/refactorings/merge-if-statements/merge-if-statements.ts
@@ -185,7 +185,6 @@ class MergeConsequentWithNestedIf extends MergeIfStatements {
   merge(): void {
     const nestedIfStatement = getNestedIfStatementIn(this.path.node.consequent);
     if (!nestedIfStatement) return;
-    if (nestedIfStatement.alternate) return;
 
     this.path.node.test = t.logicalExpression(
       "&&",
@@ -207,8 +206,6 @@ class MergeAlternateWithNestedIf extends MergeIfStatements<t.IfStatementWithAlte
   }
 
   merge(): void {
-    if (!t.isBlockStatement(this.path.node.alternate)) return;
-
     const nestedStatement = getNestedIfStatementIn(this.path.node.alternate);
     if (!nestedStatement) return;
 
@@ -237,15 +234,6 @@ class MergeAlternateAndConsequent extends MergeIfStatements<t.IfStatementWithAlt
   merge(): void {
     const nestedStatement = getNestedIfStatementIn(this.path.node.alternate);
     if (!t.isIfStatement(nestedStatement)) return;
-
-    // @ts-expect-error Technically, we're not copying the methods properly
-    const ifWithoutAlternate: t.NodePath<t.IfStatement> = {
-      ...this.path,
-      node: { ...this.path.node, alternate: null }
-    };
-    // @ts-expect-error Don't know why it complains?!
-    const alternatePath: t.NodePath = this.path.get("alternate");
-    if (!canMergeIfStatementWithPath(ifWithoutAlternate, alternatePath)) return;
 
     const test = t.logicalExpression(
       "||",


### PR DESCRIPTION
The logic was becoming complex with all the scenarios. I used a Chain of Responsibility to standardize the logic and handle all the cases smoothly.

That fixed a few bugs 👌 