### PR TITLE
Implement toggle braces for loops

### DIFF
--- a/src/refactorings/toggle-braces/index.ts
+++ b/src/refactorings/toggle-braces/index.ts
@@ -16,6 +16,10 @@ const config: RefactoringWithActionProvider = {
         return "Toggle braces (if statement)";
       }
 
+      if (path.isLoop()) {
+        return "Toggle braces (loop)";
+      }
+
       if (path.isArrowFunctionExpression()) {
         return "Toggle braces (arrow function)";
       }

--- a/src/refactorings/toggle-braces/toggle-braces.test.ts
+++ b/src/refactorings/toggle-braces/toggle-braces.test.ts
@@ -165,6 +165,48 @@ if (isValid) {
 
   return <SayBye />;
 }`
+      },
+      {
+        description: "for statement",
+        code: "for (let i = 0; i < 5; i++) cons[cursor]ole.log(i);",
+        expected: `for (let i = 0; i < 5; i++) {
+  console.log(i);
+}`
+      },
+      {
+        description: "for statement, cursor on for",
+        code: "[cursor]for (let i = 0; i < 5; i++) console.log(i);",
+        expected: `for (let i = 0; i < 5; i++) {
+  console.log(i);
+}`
+      },
+      {
+        description: "while statement",
+        code: `while (true) cons[cursor]ole.log("Hello");`,
+        expected: `while (true) {
+  console.log("Hello");
+}`
+      },
+      {
+        description: "while statement, cursor on while",
+        code: `[cursor]while (true) console.log("Hello");`,
+        expected: `while (true) {
+  console.log("Hello");
+}`
+      },
+      {
+        description: "do while statement",
+        code: `do cons[cursor]ole.log("Hello"); while (true);`,
+        expected: `do {
+  console.log("Hello");
+} while (true);`
+      },
+      {
+        description: "do while statement, cursor on do",
+        code: `[cursor]do console.log("Hello"); while (true);`,
+        expected: `do {
+  console.log("Hello");
+} while (true);`
       }
     ],
     async ({ code, expected }) => {
@@ -343,6 +385,44 @@ doAnotherThing();`
     </section>
   );
 }`
+      },
+      {
+        description: "a for statement",
+        code: `for (let i = 0; i < 5; i++) { cons[cursor]ole.log(i); }`,
+        expected: `for (let i = 0; i < 5; i++)
+  console.log(i);`
+      },
+      {
+        description: "a for statement, cursor on for",
+        code: `[cursor]for (let i = 0; i < 5; i++) { console.log(i); }`,
+        expected: `for (let i = 0; i < 5; i++)
+  console.log(i);`
+      },
+      {
+        description: "a while statement",
+        code: `while (true) { cons[cursor]ole.log("Hello"); }`,
+        expected: `while (true)
+  console.log("Hello");`
+      },
+      {
+        description: "a while statement, cursor on while",
+        code: `[cursor]while (true) { console.log("Hello"); }`,
+        expected: `while (true)
+  console.log("Hello");`
+      },
+      {
+        description: "a do while statement",
+        code: `do { cons[cursor]ole.log("Hello"); } while (true);`,
+        expected: `do
+  console.log("Hello");
+while (true);`
+      },
+      {
+        description: "a do while statement, cursor on do",
+        code: `[cursor]do { console.log("Hello"); } while (true);`,
+        expected: `do
+  console.log("Hello");
+while (true);`
       }
     ],
     async ({ code, expected }) => {
@@ -423,6 +503,30 @@ doAnotherThing();`
     </section>
   );
 }`
+      },
+      {
+        description: "an empty for statement",
+        code: `for (let i = 0; i < 5; i++) { }`
+      },
+      {
+        description: "a for statement with multiple statements",
+        code: `for (let i = 0; i < 5; i++) { console.log("Hello"); console.log("World"); }`
+      },
+      {
+        description: "an empty while statement",
+        code: `while (true) { }`
+      },
+      {
+        description: "a while statement with multiple statements",
+        code: `while (true) { console.log("Hello"); console.log("World"); }`
+      },
+      {
+        description: "an empty do while statement",
+        code: `do { } while (true);`
+      },
+      {
+        description: "a do while statement with multiple statements",
+        code: `do { console.log("Hello"); console.log("World"); } while (true);`
       }
     ],
     async ({ code }) => {


### PR DESCRIPTION
Closes #247

Toggle braces now also works for
- for statements
- for in statements
- for of statements
- while statements
- do while statements

![refactoring](https://user-images.githubusercontent.com/11138584/134735695-71c5e52b-da2a-46fd-a05a-ca4e7c2e1f50.gif)

I used the alias `Loop` to implement this refactoring. This way we don't have to handle all the different kinds of loops separately. However, I also had to change the action provider to be able to handle aliases. Without this the toggle braces refactoring was not suggested for loops.