### PR TITLE
Fix test on windows

### DIFF
--- a/src/ast/transformation.ts
+++ b/src/ast/transformation.ts
@@ -17,7 +17,6 @@ const traversePath = traverse;
 export { NodePath, Visitor, Scope } from "@babel/traverse";
 export { RootNodePath, isRootNodePath };
 export {
-  generate,
   traverseNode,
   traversePath,
   traverseAST,
@@ -33,10 +32,6 @@ export {
   Binding
 };
 export { mergeCommentsInto };
-
-function generate(ast: t.File | t.Node): Code {
-  return recast.print(ast).code;
-}
 
 function transform(code: Code, options: TraverseOptions): Transformed {
   return transformAST(parse(code), options);

--- a/src/ast/transformation.ts
+++ b/src/ast/transformation.ts
@@ -90,7 +90,9 @@ function indentWithTabs(code: Code): Code {
 }
 
 function print(ast: AST | t.Node): Code {
-  return recast.print(ast).code;
+  return recast.print(ast, {
+    lineTerminator: "\n"
+  }).code;
 }
 
 function standardizeEOL(code: Code): Code {

--- a/src/refactorings/extract/extract-variable/occurrence.ts
+++ b/src/refactorings/extract/extract-variable/occurrence.ts
@@ -298,7 +298,7 @@ class MemberExpressionOccurrence extends Occurrence<t.MemberExpression> {
   }
 
   private get parentObject(): Code {
-    return t.generate(this.path.node.object);
+    return t.print(this.path.node.object);
   }
 
   get positionOnExtractedId(): Position {

--- a/src/refactorings/react/convert-to-pure-component/convert-to-pure-component.ts
+++ b/src/refactorings/react/convert-to-pure-component/convert-to-pure-component.ts
@@ -4,6 +4,7 @@ import * as reactCodemod from "react-codemod/transforms/pure-component";
 const pureComponent = reactCodemod.default;
 
 import { Editor, Code, ErrorReason } from "../../../editor/editor";
+import * as t from "../../../ast";
 
 export { convertToPureComponent };
 
@@ -33,7 +34,7 @@ async function convertToPureComponent(editor: Editor) {
     return;
   }
 
-  await editor.write(updatedCode);
+  await editor.write(t.print(t.parse(updatedCode)));
 }
 
 type Options = {


### PR DESCRIPTION
On windows, `recast` is using `\r\n` by default and this is causing a lot of test to fail

![image](https://user-images.githubusercontent.com/1761469/145582475-7b66f930-c8b6-4016-a7e7-b59fdd3a873e.png)
