### PR TITLE
fix: exit visitor

### DIFF
--- a/src/action-providers.ts
+++ b/src/action-providers.ts
@@ -104,9 +104,17 @@ class RefactoringActionProvider implements vscode.CodeActionProvider {
     }
 
     const visitorNode = this.getVisitorNode(visitor, path);
+    // call enter shorthand of e.g. { Identifier() { ... } }
     if (typeof visitorNode === "function") {
       // @ts-expect-error visitor can expect `NodePath<File>` but `path` is typed as `NodePath<Node>`. It should be OK at runtime.
       visitorNode.bind(visitor)(path, path.state);
+    } else if (typeof visitorNode === "object" && visitorNode !== null) {
+      // call methods of e.g. { Identifier: { exit() { ... } } }
+      for (const method of Object.values(visitorNode)) {
+        if (typeof method === "function") {
+          method.bind(visitor)(path, path.state);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes the quick action provider
`forEachToForOf` used an exit method instead of the shorthand form (babel handbook), so I added the calls
> Note: `Identifier() { ... }` is shorthand for `Identifier: { enter() { ... } }`.


Before:
![before](https://user-images.githubusercontent.com/55899582/148478369-09139153-a870-4f4e-97cd-b0aff91acc56.png)

After:
![after](https://user-images.githubusercontent.com/55899582/148478336-bf4c103a-cca0-4e8b-a1aa-1942f34d8730.png)

-----------------------

I had some trouble with getting the current version to build so I tested it on v6.8.0 (3d7cc05a06ad4015313374bb27455c7ace7e0cf6) for now
![error](https://user-images.githubusercontent.com/55899582/148478302-1a632575-3d19-4c42-a899-eea54d9cf946.png)