### PR TITLE
ignore docs dir with gifs to reduce extension size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 out
 node_modules
+.DS_Store
 .vscode-test/
 .vscode-test-web/
 *.vsix

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,7 +1,7 @@
 .github/**
 .vscode/**
 dist/**
-docs/*
+docs/**
 !docs/logo
 /docs/logo/*
 !docs/logo/abracadabra-vignette.png


### PR DESCRIPTION
I just noticed that installing this extension takes forever. Published vsix is 40mb. After ignoring docs with gifs `vsce` says it is 5mb now.

ImageOptim said it is possible to save 11mb in repo. ~~However GIFs are evil and I suggest to remove them from repo and use fancy codes instead.~~ UPD: I understand there is no other way to demonstrate functionality, however I believe in some future we can use SVGs for that.

You can also [reduce bundle size](https://github.com/prettier/prettier-vscode/pull/2302#issuecomment-1003753084) with esbuild. It can also give you really fast builds!
WDYT?

Also note that it is much simpler to ignore everything in `.vscodeignore` and unignore only needed assets.