### PR TITLE
Convert Switch case with only a default case to if-statement

### DIFF
--- a/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.test.ts
+++ b/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.test.ts
@@ -186,6 +186,18 @@ if (name === "John" || name === "Johnny") {
 }
 
 return sayHello();`
+      },
+      {
+        description: "switch default",
+        code: `switch(name) {
+  default:
+    item.quality += 1;
+    break;
+}`,
+        expected: `if(true) {
+  item.quality += 1;
+}`,
+        only: true
       }
     ],
     async ({ code, expected }) => {

--- a/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.test.ts
+++ b/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.test.ts
@@ -194,10 +194,9 @@ return sayHello();`
     item.quality += 1;
     break;
 }`,
-        expected: `if(true) {
+        expected: `if (true) {
   item.quality += 1;
-}`,
-        only: true
+}`
       }
     ],
     async ({ code, expected }) => {

--- a/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.ts
+++ b/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.ts
@@ -132,11 +132,6 @@ function linkIfStatements(node: t.SwitchStatement, statements: t.Statement[]) {
   }
 
   const firstStatement = statements[0];
-  if (!t.isIfStatement(firstStatement)) {
-    throw new Error(
-      "Cannot convert switch statement with just a single default case."
-    );
-  }
 
   if (statements.length === 1) {
     return firstStatement;

--- a/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.ts
+++ b/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.ts
@@ -93,16 +93,11 @@ function convertNode(node: t.SwitchStatement): t.Statement {
         throw new Error("default case can only be the last case");
       }
 
-      if (statements.length !== 0) {
-        statements.push(caseWithoutBreak(caseNode, isLast));
-      } else {
-        statements.push(
-          t.ifStatement(
-            t.booleanLiteral(true),
-            caseWithoutBreak(caseNode, isLast)
-          )
-        );
+      let statement: t.Statement = caseWithoutBreak(caseNode, isLast);
+      if (statements.length === 0) {
+        statement = t.ifStatement(t.booleanLiteral(true), statement);
       }
+      statements.push(statement);
       return;
     }
 

--- a/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.ts
+++ b/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.ts
@@ -93,7 +93,16 @@ function convertNode(node: t.SwitchStatement): t.Statement {
         throw new Error("default case can only be the last case");
       }
 
-      statements.push(caseWithoutBreak(caseNode, isLast));
+      if (statements.length !== 0) {
+        statements.push(caseWithoutBreak(caseNode, isLast));
+      } else {
+        statements.push(
+          t.ifStatement(
+            t.booleanLiteral(true),
+            caseWithoutBreak(caseNode, isLast)
+          )
+        );
+      }
       return;
     }
 


### PR DESCRIPTION
Before we are not able to convert switch-to.if when there are not cases. Now you can convert a default switch to if statement then remove dead code. Related to https://github.com/nicoespeon/abracadabra/issues/568

![vscode-new-switch](https://user-images.githubusercontent.com/8685132/164477597-c400c53a-6a3e-44a4-a95f-b97e82d79df0.gif)



What an amazing Developer experiencie!!! Congrats :)