### PR TITLE
[New Refactoring] Extract useCallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "webpack-cli": "4.9.2"
   },
   "dependencies": {
+    "@babel/eslint-parser": "^7.17.0",
     "@babel/parser": "7.17.10",
     "@babel/traverse": "7.17.3",
     "@babel/types": "7.17.10",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "buffer": "6.0.3",
     "chai": "4.3.6",
     "eslint-config-prettier": "8.4.0",
-    "eslint": "8.14.0",
     "glob": "7.2.0",
     "husky": "7.0.4",
     "hygen": "6.2.0",
@@ -100,8 +99,8 @@
     "typescript": "4.6.3",
     "util": "0.12.4",
     "vsce": "2.7.0",
-    "webpack-cli": "4.9.2",
-    "webpack": "5.72.0"
+    "webpack": "5.72.0",
+    "webpack-cli": "4.9.2"
   },
   "dependencies": {
     "@babel/parser": "7.17.10",
@@ -109,6 +108,8 @@
     "@babel/types": "7.17.10",
     "@typescript/vfs": "1.3.5",
     "change-case": "4.1.2",
+    "eslint": "8.14.0",
+    "eslint-plugin-react-hooks": "^4.5.0",
     "jscodeshift": "0.13.0",
     "minimatch": "5.0.1",
     "pluralize": "8.0.0",

--- a/src/ast/transformation.ts
+++ b/src/ast/transformation.ts
@@ -1,4 +1,4 @@
-import { parse as babelParse } from "@babel/parser";
+import { parse as babelParse, ParserOptions } from "@babel/parser";
 import traverse, { NodePath, TraverseOptions, Visitor } from "@babel/traverse";
 import * as t from "@babel/types";
 import * as recast from "recast";
@@ -10,6 +10,52 @@ export const traversePath = traverse;
 
 export { Binding, NodePath, Scope } from "@babel/traverse";
 export type { Visitor };
+
+export const BABEL_PARSER_OPTIONS: ParserOptions = {
+  sourceType: "module",
+  allowImportExportEverywhere: true,
+  allowReturnOutsideFunction: true,
+  startLine: 1,
+
+  // Tokens are necessary for Recast to do its magic ✨
+  tokens: true,
+
+  plugins: [
+    "asyncGenerators",
+    "bigInt",
+    "classPrivateMethods",
+    "classPrivateProperties",
+    "classProperties",
+    // Not compatible with "decorators-legacy"
+    // "decorators",
+    "decorators-legacy",
+    "doExpressions",
+    "dynamicImport",
+    // Make tests fail, not sure why
+    // "estree",
+    "exportDefaultFrom",
+    "exportNamespaceFrom",
+    // Not compatible with "typescript"
+    // "flow",
+    // "flowComments",
+    "functionBind",
+    "functionSent",
+    "importMeta",
+    "jsx",
+    "logicalAssignment",
+    "nullishCoalescingOperator",
+    "numericSeparator",
+    "objectRestSpread",
+    "optionalCatchBinding",
+    "optionalChaining",
+    "partialApplication",
+    ["pipelineOperator", { proposal: "minimal" }],
+    "placeholders",
+    "throwExpressions",
+    "topLevelAwait",
+    "typescript"
+  ]
+};
 
 export function transform(code: Code, options: TraverseOptions): Transformed {
   return transformAST(parse(code), options);
@@ -86,54 +132,7 @@ export function parse(code: Code): AST {
   try {
     return recast.parse(code, {
       parser: {
-        parse: (source: Code) =>
-          babelParse(source, {
-            sourceType: "module",
-            allowImportExportEverywhere: true,
-            allowReturnOutsideFunction: true,
-            startLine: 1,
-
-            // Tokens are necessary for Recast to do its magic ✨
-            tokens: true,
-
-            plugins: [
-              "asyncGenerators",
-              "bigInt",
-              "classPrivateMethods",
-              "classPrivateProperties",
-              "classProperties",
-              // Not compatible with "decorators-legacy"
-              // "decorators",
-              "decorators-legacy",
-              "doExpressions",
-              "dynamicImport",
-              // Make tests fail, not sure why
-              // "estree",
-              "exportDefaultFrom",
-              "exportNamespaceFrom",
-              // Not compatible with "typescript"
-              // "flow",
-              // "flowComments",
-              "functionBind",
-              "functionSent",
-              "importMeta",
-              "jsx",
-              "logicalAssignment",
-              "nullishCoalescingOperator",
-              "numericSeparator",
-              "objectRestSpread",
-              "optionalCatchBinding",
-              "optionalChaining",
-              "partialApplication",
-              ["pipelineOperator", { proposal: "minimal" }],
-              "placeholders",
-              "throwExpressions",
-              "topLevelAwait",
-              "typescript"
-              // Not compatible with "placeholders"
-              // "v8intrinsic"
-            ]
-          })
+        parse: (source: Code) => babelParse(source, BABEL_PARSER_OPTIONS)
       },
       // VS Code considers tabs to be of size 1
       tabWidth: 1

--- a/src/editor/error-reason.ts
+++ b/src/editor/error-reason.ts
@@ -21,6 +21,7 @@ export enum ErrorReason {
   DidNotFindIfStatementToAddBraces,
   DidNotFindDeadCode,
   DidNotFindForEachToConvertToForOf,
+  DidNotFindExtractUseCallback,
   DidNotFindForLoopToConvert,
   DidNotFindStatementToMerge,
   DidNotFindNestedIf,
@@ -127,6 +128,9 @@ export function toString(reason: ErrorReason): string {
 
     case ErrorReason.DidNotFindForEachToConvertToForOf:
       return didNotFind("a for each to convert");
+
+    case ErrorReason.DidNotFindExtractUseCallback:
+      return didNotFind("an inline JSX function to extract");
 
     case ErrorReason.DidNotFindForLoopToConvert:
       return didNotFind("a valid for loop to convert");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ import moveStatementUp from "./refactorings/move-statement-up";
 import moveToExistingFile from "./refactorings/move-to-existing-file";
 import invertBooleanLogic from "./refactorings/invert-boolean-logic";
 import reactConvertToPureComponent from "./refactorings/react/convert-to-pure-component";
+import reactExtractUseCallback from "./refactorings/react/extract-use-callback";
 import removeDeadCode from "./refactorings/remove-dead-code";
 import removeRedundantElse from "./refactorings/remove-redundant-else";
 import renameSymbol from "./refactorings/rename-symbol";
@@ -53,7 +54,7 @@ const refactorings: { [key: string]: ConfiguredRefactoring } = {
   reactOnly: {
     languages: ["javascriptreact", "typescriptreact"],
     withoutActionProvider: [reactConvertToPureComponent],
-    withActionProvider: []
+    withActionProvider: [reactExtractUseCallback]
   },
   allButVue: {
     languages: [

--- a/src/refactorings/react/extract-use-callback/extract-use-callback.test.ts
+++ b/src/refactorings/react/extract-use-callback/extract-use-callback.test.ts
@@ -1,0 +1,89 @@
+import { InMemoryEditor } from "../../../editor/adapters/in-memory-editor";
+import { Code, ErrorReason } from "../../../editor/editor";
+import { testEach } from "../../../tests-helpers";
+import { extractUseCallback } from "./extract-use-callback";
+
+describe("Extract useCallback", () => {
+  testEach<{ code: Code; expected: Code }>(
+    "should extract useCallback from an inline function",
+    [
+      {
+        description: "arrow expression",
+        code: `
+function Bar() {
+  return <Foo onFoo={[cursor](e) => console.log(e)} />;
+}`,
+        expected: `
+function Bar() {
+  const onFoo = useCallback(e => console.log(e), []);
+  return <Foo onFoo={onFoo} />;
+}`
+      },
+      {
+        description: "function expression",
+        code: `
+function Bar() {
+  return (
+    <Foo onFoo={[cursor]function handleFoo() {
+      console.log(e);
+    }} />
+  );
+}`,
+        expected: `
+function Bar() {
+  const onFoo = useCallback(function handleFoo() {
+    console.log(e);
+  }, []);
+
+  return <Foo onFoo={onFoo} />;
+}`
+      },
+      {
+        description: "uses a unique name",
+        code: `
+function Bar({onFoo}) {
+  return <Foo onFoo={[cursor](e) => {console.log(e); onFoo(e); }} />;
+}`,
+        expected: `
+function Bar({onFoo}) {
+  const onFoo2 = useCallback(e => {console.log(e); onFoo(e); }, []);
+  return <Foo onFoo={onFoo2} />;
+}`
+      },
+      {
+        description: "adds a block if necessary",
+        code: `
+const Bar = () => <Foo onFoo={[cursor](e) => {console.log(e); onFoo(e); }} />;`,
+        expected: `
+const Bar = () => {
+  const onFoo = useCallback(e => {console.log(e); onFoo(e); }, []);
+  return <Foo onFoo={onFoo} />;
+};`
+      }
+    ].map(({ description, code, expected }) => ({
+      description,
+      code: code.trim(),
+      expected: expected.trim()
+    })),
+
+    async ({ code, expected }) => {
+      const editor = new InMemoryEditor(code);
+
+      await extractUseCallback(editor);
+
+      expect(editor.code).toBe(expected);
+    }
+  );
+
+  it("should show an error message if refactoring can't be made", async () => {
+    const code = `// This is a comment, can't be refactored`;
+    const editor = new InMemoryEditor(code);
+    jest.spyOn(editor, "showError");
+
+    await extractUseCallback(editor);
+
+    expect(editor.showError).toBeCalledWith(
+      ErrorReason.DidNotFindExtractUseCallback
+    );
+  });
+});

--- a/src/refactorings/react/extract-use-callback/extract-use-callback.test.ts
+++ b/src/refactorings/react/extract-use-callback/extract-use-callback.test.ts
@@ -46,8 +46,20 @@ function Bar({onFoo}) {
 }`,
         expected: `
 function Bar({onFoo}) {
-  const onFoo2 = useCallback(e => {console.log(e); onFoo(e); }, []);
+  const onFoo2 = useCallback(e => {console.log(e); onFoo(e); }, [onFoo]);
   return <Foo onFoo={onFoo2} />;
+}`
+      },
+      {
+        description: "adds dependencies using react-hooks/exhaustive-deps",
+        code: `
+function Bar({a, b, c}) {
+  return <Foo onFoo={[cursor]() => a(b, c)} />;
+}`,
+        expected: `
+function Bar({a, b, c}) {
+  const onFoo = useCallback(() => a(b, c), [a, b, c]);
+  return <Foo onFoo={onFoo} />;
 }`
       },
       {

--- a/src/refactorings/react/extract-use-callback/extract-use-callback.ts
+++ b/src/refactorings/react/extract-use-callback/extract-use-callback.ts
@@ -1,0 +1,84 @@
+import { template } from "@babel/core";
+import * as t from "../../../ast";
+import { Editor, ErrorReason } from "../../../editor/editor";
+import { Selection } from "../../../editor/selection";
+
+export async function extractUseCallback(editor: Editor) {
+  const { code, selection } = editor;
+  const updatedCode = updateCode(t.parse(code), selection);
+
+  if (!updatedCode.hasCodeChanged) {
+    editor.showError(ErrorReason.DidNotFindExtractUseCallback);
+    return;
+  }
+
+  await editor.write(updatedCode.code);
+}
+
+function updateCode(ast: t.AST, selection: Selection): t.Transformed {
+  return t.transformAST(
+    ast,
+    createVisitor(selection, (path, { attrName, fn }) => {
+      const scopePath = path.scope.path;
+      if (!scopePath.isFunction()) {
+        return;
+      }
+
+      let extractedName = attrName;
+      let counter = 2;
+      while (path.scope.hasBinding(extractedName)) {
+        extractedName = attrName + counter;
+        counter++;
+
+        // Avoid an infinite loop, just in case
+        if (counter > 10) {
+          return;
+        }
+      }
+
+      const id = t.identifier(extractedName);
+      const node = template.statement`
+        const ID = useCallback(FN, []);
+      `({ ID: id, FN: fn.node });
+
+      const body = scopePath.get("body");
+      if (body.isExpression()) {
+        body.replaceWith(
+          t.blockStatement([node, t.returnStatement(body.node)])
+        );
+        fn.replaceWith(id);
+        return;
+      }
+
+      const jsxStatement = path.getStatementParent();
+      if (!jsxStatement) return;
+
+      jsxStatement.insertBefore(node);
+      fn.replaceWith(id);
+    })
+  );
+}
+
+export function createVisitor(
+  selection: Selection,
+  onMatch: (
+    path: t.SelectablePath<t.JSXAttribute>,
+    args: {
+      attrName: string;
+      fn: t.NodePath<t.FunctionExpression | t.ArrowFunctionExpression>;
+    }
+  ) => void
+): t.Visitor {
+  return {
+    JSXAttribute(path) {
+      if (!selection.isInsidePath(path)) return;
+      const name = path.get("name");
+      if (!name.isJSXIdentifier()) return;
+      const value = path.get("value");
+      if (!value.isJSXExpressionContainer()) return;
+      const fn = value.get("expression");
+      if (!fn.isArrowFunctionExpression() && !fn.isFunctionExpression()) return;
+      onMatch(path, { attrName: name.node.name, fn });
+    }
+  };
+}

--- a/src/refactorings/react/extract-use-callback/extract-use-callback.ts
+++ b/src/refactorings/react/extract-use-callback/extract-use-callback.ts
@@ -1,6 +1,7 @@
 import { template } from "@babel/core";
 import { ESLint } from "eslint";
 import * as t from "../../../ast";
+import { BABEL_PARSER_OPTIONS } from "../../../ast";
 import { Editor, ErrorReason } from "../../../editor/editor";
 import { Selection } from "../../../editor/selection";
 
@@ -8,16 +9,14 @@ const eslint = new ESLint({
   fix: true,
   useEslintrc: false,
   overrideConfig: {
+    parser: "@babel/eslint-parser",
     plugins: ["react-hooks"],
-    rules: {
-      "react-hooks/exhaustive-deps": "error"
-    },
+    rules: { "react-hooks/exhaustive-deps": "error" },
     parserOptions: {
-      ecmaFeatures: {
-        jsx: true
-      },
+      ecmaFeatures: { jsx: true },
       ecmaVersion: 6,
-      sourceType: "module"
+      sourceType: "module",
+      babelOptions: { parserOpts: BABEL_PARSER_OPTIONS }
     }
   }
 });
@@ -38,6 +37,7 @@ export async function extractUseCallback(editor: Editor) {
 
 async function fixReactHooksExhaustiveDeps(code: string): Promise<string> {
   const results = await eslint.lintText(code);
+  console.log(results[0]?.messages);
   const fix = results[0]?.messages[0]?.suggestions?.[0]?.fix;
   return fix
     ? code.slice(0, fix.range[0]) + fix.text + code.slice(fix.range[1])

--- a/src/refactorings/react/extract-use-callback/extract-use-callback.ts
+++ b/src/refactorings/react/extract-use-callback/extract-use-callback.ts
@@ -37,7 +37,6 @@ export async function extractUseCallback(editor: Editor) {
 
 async function fixReactHooksExhaustiveDeps(code: string): Promise<string> {
   const results = await eslint.lintText(code);
-  console.log(results[0]?.messages);
   const fix = results[0]?.messages[0]?.suggestions?.[0]?.fix;
   return fix
     ? code.slice(0, fix.range[0]) + fix.text + code.slice(fix.range[1])

--- a/src/refactorings/react/extract-use-callback/index.ts
+++ b/src/refactorings/react/extract-use-callback/index.ts
@@ -1,0 +1,16 @@
+import { RefactoringWithActionProvider } from "../../../types";
+import { extractUseCallback, createVisitor } from "./extract-use-callback";
+
+const config: RefactoringWithActionProvider = {
+  command: {
+    key: "extractUseCallback",
+    operation: extractUseCallback,
+    title: "Extract to useCallback"
+  },
+  actionProvider: {
+    message: "Extract to useCallback",
+    createVisitor
+  }
+};
+
+export default config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3532,6 +3532,11 @@ eslint-plugin-prettier@^4.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz#5f762dfedf8b2cf431c689f533c9d3fa5dcf25ad"
+  integrity sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==
+
 eslint-scope@5.1.1, eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,6 +42,15 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
+"@babel/eslint-parser@^7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.17.0.tgz#eabb24ad9f0afa80e5849f8240d0e5facc2d90d6"
+  integrity sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==
+  dependencies:
+    eslint-scope "^5.1.1"
+    eslint-visitor-keys "^2.1.0"
+    semver "^6.3.0"
+
 "@babel/generator@^7.17.10", "@babel/generator@^7.17.3", "@babel/generator@^7.7.2":
   version "7.17.10"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.10.tgz#c281fa35b0c349bbe9d02916f4ae08fc85ed7189"
@@ -3572,7 +3581,7 @@ eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
-eslint-visitor-keys@^2.0.0:
+eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==


### PR DESCRIPTION
Add a new React-specific refactoring to extract an inline function from a JSX prop to a `useCallback` call.

## Handled
- Arrow and function expressions
- Rename the extracted identifier if it conflicts
- Add a block if it was an arrow expression without braces

## Not Handled
- Add types to the function
- Infer dependencies (always uses an empty array) - use the React hooks ESLint fixers for that

https://user-images.githubusercontent.com/897931/167899020-6e456b0c-6c61-4b02-abdf-449cb9ce8a68.mp4

## Test Plan

- Unit tests
- "Run in debugger" and test on a real React file