### PR TITLE
Enhance the default name for new expression

### DIFF
--- a/src/refactorings/extract/extract-variable/extract-variable.extractable.test.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.extractable.test.ts
@@ -396,20 +396,20 @@ if (
       {
         description: "a class instantiation (cursor on new expression)",
         code: `console.log([cursor]new Card("jack"));`,
-        expected: `const extracted = new Card("jack");
-console.log(extracted);`
+        expected: `const card = new Card("jack");
+console.log(card);`
       },
       {
         description: "a class instantiation (cursor on class identifier)",
         code: `console.log(new [cursor]Card("jack"));`,
-        expected: `const extracted = new Card("jack");
-console.log(extracted);`
+        expected: `const card = new Card("jack");
+console.log(card);`
       },
       {
         description: "a thrown error",
         code: `throw new Er[cursor]ror("It failed");`,
-        expected: `const extracted = new Error("It failed");
-throw extracted;`
+        expected: `const error = new Error("It failed");
+throw error;`
       },
       {
         description: "a call expression parameter (multi-lines)",
@@ -462,9 +462,9 @@ doSomething([
         code: `doSomething([
   [cursor]new Author("Eliott")
 ]);`,
-        expected: `const extracted = new Author("Eliott");
+        expected: `const author = new Author("Eliott");
 doSomething([
-  extracted
+  author
 ]);`
       },
       {

--- a/src/refactorings/extract/extract-variable/extract-variable.multiple-occurrences.test.ts
+++ b/src/refactorings/extract/extract-variable/extract-variable.multiple-occurrences.test.ts
@@ -407,9 +407,9 @@ sendMessage(extracted);`
         description: "new expression",
         code: `console.log([cursor]new Actor("John"));
 sendMessage(new Actor("John"));`,
-        expected: `const extracted = new Actor("John");
-console.log(extracted);
-sendMessage(extracted);`
+        expected: `const actor = new Actor("John");
+console.log(actor);
+sendMessage(actor);`
       },
       {
         description: "JSX Element",

--- a/src/refactorings/extract/extract-variable/occurrence.ts
+++ b/src/refactorings/extract/extract-variable/occurrence.ts
@@ -7,7 +7,8 @@ import {
   Variable,
   StringLiteralVariable,
   MemberExpressionVariable,
-  ShorthandVariable
+  ShorthandVariable,
+  NewExpressionVariable
 } from "./variable";
 import { Parts } from "./parts";
 import { DestructureStrategy } from "./destructure-strategy";
@@ -47,6 +48,10 @@ export function createOccurrence(
         path as t.NodePath<t.OptionalMemberExpression>
       )
     );
+  }
+
+  if (path.isNewExpression()) {
+    return new Occurrence(path, loc, new NewExpressionVariable(path));
   }
 
   if (path.isStringLiteral()) {

--- a/src/refactorings/extract/extract-variable/variable.ts
+++ b/src/refactorings/extract/extract-variable/variable.ts
@@ -87,6 +87,15 @@ export class StringLiteralVariable extends Variable<t.Node> {
   }
 }
 
+export class NewExpressionVariable extends Variable<t.NewExpression> {
+  constructor(path: t.NodePath<t.NewExpression>) {
+    super(path);
+    if (path.node.callee.type === "Identifier") {
+      this.tryToSetNameWith(camelCase(path.node.callee.name));
+    }
+  }
+}
+
 export class MemberExpressionVariable extends Variable<
   t.MemberExpression | t.OptionalMemberExpression
 > {


### PR DESCRIPTION
When extracting a class instantiation, for instance `new ImageEditor()`, provide a more user-friendly default name (instead of `extracted`). The new default is the camel-cased class name, `imageEditor` in the example above.