### PR TITLE
Preserve comments when replacing nodes

### DIFF
--- a/src/refactorings/convert-for-each-to-for-of/convert-for-each-to-for-of.test.ts
+++ b/src/refactorings/convert-for-each-to-for-of/convert-for-each-to-for-of.test.ts
@@ -169,6 +169,42 @@ items.forEach((item) => {
     console.log(value);
   }
 });`
+      },
+      {
+        description: "preserves comments",
+        code: `
+// leading comment
+[cursor]items.forEach((item) => {
+  console.log(item);
+});
+// trailing comment`,
+        expected: `
+// leading comment
+for (const item of items) {
+  console.log(item);
+}
+// trailing comment`
+      },
+      {
+        description: "preserves comments for return",
+        code: `
+items.forEach((item) => {
+  if (item.type === 'foo') {
+    // leading comment
+    return;
+    // trailing comment
+  }
+  console.log(item);
+});`,
+        expected: `
+for (const item of items) {
+  if (item.type === 'foo') {
+    // leading comment
+    continue;
+    // trailing comment
+  }
+  console.log(item);
+}`
       }
     ].map(({ description, code, expected }) => ({
       description,

--- a/src/refactorings/convert-for-each-to-for-of/convert-for-each-to-for-of.ts
+++ b/src/refactorings/convert-for-each-to-for-of/convert-for-each-to-for-of.ts
@@ -44,7 +44,7 @@ function updateCode(
               path.isFunctionDeclaration()
           );
           if (parentFunction !== fnPath) return;
-          returnPath.replaceWith(t.continueStatement());
+          t.replaceWithPreservingComments(returnPath, t.continueStatement());
         }
       });
 
@@ -53,7 +53,8 @@ function updateCode(
           path.parentPath.node.loc.start
         ).line;
       }
-      path.parentPath.replaceWith(
+      t.replaceWithPreservingComments(
+        path.parentPath,
         t.forOfStatement(
           t.variableDeclaration("const", [t.variableDeclarator(item)]),
           items,

--- a/src/refactorings/convert-for-to-for-each/convert-for-to-for-each.test.ts
+++ b/src/refactorings/convert-for-to-for-each/convert-for-to-for-each.test.ts
@@ -274,6 +274,19 @@ items.forEach(item => {
         expected: `foo.bar.forEach(item => {
   console.log(item);
 });`
+      },
+      {
+        description: "preserves comments",
+        code: `// leading comment
+[cursor]for (let i = 0; i < items.length; i++) {
+  console.log(items[i]);
+}
+// trailing comment`,
+        expected: `// leading comment
+items.forEach(item => {
+  console.log(item);
+});
+// trailing comment`
       }
     ],
     async ({ code, expected }) => {

--- a/src/refactorings/convert-for-to-for-each/convert-for-to-for-each.ts
+++ b/src/refactorings/convert-for-to-for-each/convert-for-to-for-each.ts
@@ -40,7 +40,10 @@ function updateCode(
         : t.blockStatement([body]);
 
       forLoopStartLine = Position.fromAST(path.node.loc.start).line;
-      path.replaceWith(t.forEach(list, getParams(forEachBody), forEachBody));
+      t.replaceWithPreservingComments(
+        path,
+        t.forEach(list, getParams(forEachBody), forEachBody)
+      );
       path.stop();
     })
   );

--- a/src/refactorings/convert-if-else-to-switch/convert-if-else-to-switch.test.ts
+++ b/src/refactorings/convert-if-else-to-switch/convert-if-else-to-switch.test.ts
@@ -222,6 +222,31 @@ case "John":
 default:
   return sayHello();
 }`
+      },
+      {
+        description: "preserves comments",
+        code: `// leading comment
+[cursor]if (name === "Jane") {
+  sayHelloToJane();
+} else if (name === "John") {
+  sayHelloToJohn();
+} else {
+  sayHello();
+}
+// trailing comment`,
+        expected: `// leading comment
+switch (name) {
+case "Jane":
+  sayHelloToJane();
+  break;
+case "John":
+  sayHelloToJohn();
+  break;
+default:
+  sayHello();
+  break;
+}
+// trailing comment`
       }
     ],
     async ({ code, expected }) => {

--- a/src/refactorings/convert-if-else-to-switch/convert-if-else-to-switch.ts
+++ b/src/refactorings/convert-if-else-to-switch/convert-if-else-to-switch.ts
@@ -18,7 +18,7 @@ function updateCode(ast: t.AST, selection: Selection): t.Transformed {
   return t.transformAST(
     ast,
     createVisitor(selection, (path, convertedNode) => {
-      path.replaceWith(convertedNode);
+      t.replaceWithPreservingComments(path, convertedNode);
       path.stop();
     })
   );

--- a/src/refactorings/convert-if-else-to-ternary/convert-if-else-to-ternary.test.ts
+++ b/src/refactorings/convert-if-else-to-ternary/convert-if-else-to-ternary.test.ts
@@ -113,6 +113,23 @@ describe("Convert If/Else to Ternary", () => {
 }`
       },
       {
+        description: "preserve comments before and after condition",
+        code: `function reservationMode(daysInAdvance) {
+  // leading comment
+  if ([cursor]daysInAdvance > 10) {
+    return "early";
+  } else {
+    return "normal";
+  }
+  // trailing comment
+}`,
+        expected: `function reservationMode(daysInAdvance) {
+  // leading comment
+  return daysInAdvance > 10 ? "early" : "normal";
+  // trailing comment
+}`
+      },
+      {
         description: "preserve comments for returned values",
         code: `function reservationMode(daysInAdvance) {
   if ([cursor]daysInAdvance > 10) {

--- a/src/refactorings/convert-if-else-to-ternary/convert-if-else-to-ternary.ts
+++ b/src/refactorings/convert-if-else-to-ternary/convert-if-else-to-ternary.ts
@@ -18,7 +18,7 @@ function updateCode(ast: t.AST, selection: Selection): t.Transformed {
   return t.transformAST(
     ast,
     createVisitor(selection, (path, node) => {
-      path.replaceWith(node);
+      t.replaceWithPreservingComments(path, node);
       path.stop();
     })
   );

--- a/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.test.ts
+++ b/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.test.ts
@@ -206,6 +206,40 @@ return sayHello();`
         expected: `if (tempScore === 12) {
   score += scores[tempScore];
 }`
+      },
+      {
+        description: "preserves comments",
+        code: `// leading comment
+[cursor]switch (name) {
+case "Jane":
+  sayHelloToJane();
+  break;
+default:
+  sayHello();
+  break;
+}
+// trailing comment`,
+        expected: `// leading comment
+if (name === "Jane") {
+  sayHelloToJane();
+} else {
+  sayHello();
+}
+// trailing comment`
+      },
+      {
+        description:
+          "preserves comments if switch only contains default statement",
+        code: `// leading comment
+[cursor]switch (tempScore) {
+  default:
+    score += scores[tempScore];
+    break;
+}
+// trailing comment`,
+        expected: `// leading comment
+score += scores[tempScore];
+// trailing comment`
       }
     ],
     async ({ code, expected }) => {

--- a/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.ts
+++ b/src/refactorings/convert-switch-to-if-else/convert-switch-to-if-else.ts
@@ -20,9 +20,9 @@ function updateCode(ast: t.AST, selection: Selection): t.Transformed {
     ast,
     createVisitor(selection, (path, convertedNode) => {
       if (t.isBlockStatement(convertedNode)) {
-        path.replaceWithMultiple(convertedNode.body);
+        t.replaceWithMultiplePreservingComments(path, convertedNode.body);
       } else {
-        path.replaceWith(convertedNode);
+        t.replaceWithPreservingComments(path, convertedNode);
       }
       path.stop();
     })

--- a/src/refactorings/convert-ternary-to-if-else/convert-ternary-to-if-else.test.ts
+++ b/src/refactorings/convert-ternary-to-if-else/convert-ternary-to-if-else.test.ts
@@ -22,6 +22,23 @@ describe("Convert Ternary to If/Else", () => {
 }`
       },
       {
+        description: "preserves comments for return",
+        code: `function reservationMode(daysInAdvance) {
+  // leading comment
+  return daysInA[cursor]dvance > 10 ? "early" : "normal";
+  // trailing comment
+}`,
+        expected: `function reservationMode(daysInAdvance) {
+  // leading comment
+  if (daysInAdvance > 10) {
+    return "early";
+  } else {
+    return "normal";
+  }
+  // trailing comment
+}`
+      },
+      {
         description: "assignment expression",
         code: `function reservationMode(daysInAdvance) {
   let mode;
@@ -60,6 +77,29 @@ describe("Convert Ternary to If/Else", () => {
 }`
       },
       {
+        description: "preserves comments for assignment expression",
+        code: `function reservationMode(daysInAdvance) {
+  let mode;
+  // leading comment
+  mode = daysInA[cursor]dvance > 10 ? "early" : "normal";
+  // trailing comment
+  return mode;
+}`,
+        expected: `function reservationMode(daysInAdvance) {
+  let mode;
+
+  // leading comment
+  if (daysInAdvance > 10) {
+    mode = "early";
+  } else {
+    mode = "normal";
+  }
+
+  // trailing comment
+  return mode;
+}`
+      },
+      {
         description: "variable declaration",
         code: `function reservationMode(daysInAdvance) {
   const mode = d[cursor]aysInAdvance > 10 ? "early" : "normal";
@@ -74,6 +114,28 @@ describe("Convert Ternary to If/Else", () => {
     mode = "normal";
   }
 
+  return mode;
+}`
+      },
+      {
+        description: "preserves comments for variable declaration",
+        code: `function reservationMode(daysInAdvance) {
+  // leading comment
+  const mode = d[cursor]aysInAdvance > 10 ? "early" : "normal";
+  // trailing comment
+  return mode;
+}`,
+        expected: `function reservationMode(daysInAdvance) {
+  // leading comment
+  let mode;
+
+  if (daysInAdvance > 10) {
+    mode = "early";
+  } else {
+    mode = "normal";
+  }
+
+  // trailing comment
   return mode;
 }`
       },
@@ -218,6 +280,23 @@ if (args.forcelink) {
   } else {
     doThat();
   }
+}`
+      },
+      {
+        description: "preserves comments for ternary that is not returned",
+        code: `function doSomething(isValid) {
+  // leading comment
+  [cursor]isValid ? doThis() : doThat();
+  // trailing comment
+}`,
+        expected: `function doSomething(isValid) {
+  // leading comment
+  if (isValid) {
+    doThis();
+  } else {
+    doThat();
+  }
+  // trailing comment
 }`
       }
     ],

--- a/src/refactorings/convert-ternary-to-if-else/convert-ternary-to-if-else.ts
+++ b/src/refactorings/convert-ternary-to-if-else/convert-ternary-to-if-else.ts
@@ -30,7 +30,8 @@ function updateCode(
     createVisitor(selection, (path: t.NodePath<t.ConditionalExpression>) => {
       const { parentPath, node } = path;
       if (t.isReturnStatement(parentPath.node)) {
-        parentPath.replaceWith(
+        t.replaceWithPreservingComments(
+          parentPath,
           createIfStatement(selection, node, t.returnStatement)
         );
 
@@ -46,7 +47,8 @@ function updateCode(
         const expressionParentPath = parentPath.parentPath;
         if (!expressionParentPath) return;
 
-        expressionParentPath.replaceWith(
+        t.replaceWithPreservingComments(
+          expressionParentPath,
           createIfStatement(selection, node, (expression) =>
             createAssignment(operator, left, expression)
           )
@@ -68,7 +70,7 @@ function updateCode(
 
         // VariableDeclarator is contained in a VariableDeclaration
         // => replace parentPath's parent path
-        parentPath.parentPath.replaceWithMultiple([
+        t.replaceWithMultiplePreservingComments(parentPath.parentPath, [
           createLetDeclaration(id),
           createIfStatement(selection, node, (expression) =>
             createAssignment("=", id, expression)
@@ -79,7 +81,8 @@ function updateCode(
         return;
       }
 
-      parentPath.replaceWith(
+      t.replaceWithPreservingComments(
+        parentPath,
         createIfStatement(selection, node, t.expressionStatement)
       );
       parentPath.stop();

--- a/src/refactorings/convert-to-arrow-function/convert-to-arrow-function.ts
+++ b/src/refactorings/convert-to-arrow-function/convert-to-arrow-function.ts
@@ -47,7 +47,7 @@ function updateCode(
         return;
       }
 
-      path.replaceWith(converter.replacementNode);
+      t.replaceWithPreservingComments(path, converter.replacementNode);
       path.stop();
     })
   );
@@ -73,11 +73,7 @@ class FunctionDeclarationConverter implements Converter {
       t.toArrowFunctionExpression(this.path)
     );
 
-    const variableDeclaration = t.variableDeclaration("const", [declarator]);
-    // @ts-expect-error Recast does use a `comments` attribute.
-    variableDeclaration.comments = node.comments;
-
-    return variableDeclaration;
+    return t.variableDeclaration("const", [declarator]);
   }
 
   get hasReferenceBefore() {

--- a/src/refactorings/convert-to-template-literal/convert-to-template-literal.test.ts
+++ b/src/refactorings/convert-to-template-literal/convert-to-template-literal.test.ts
@@ -64,6 +64,19 @@ const lastName = "Doe";`
         description: "string literal with backticks",
         code: "const a = 'Hello[cursor] `you`'",
         expected: "const a = `Hello \\`you\\``"
+      },
+      {
+        description: "preserves comments",
+        code: `const name = 
+  // leading comment
+  [cursor]"Jane"
+  // trailing comment
+  ;`,
+        expected: `const name = 
+  // leading comment
+  \`Jane\`
+  // trailing comment
+  ;`
       }
     ],
     async ({ code, expected }) => {

--- a/src/refactorings/convert-to-template-literal/convert-to-template-literal.ts
+++ b/src/refactorings/convert-to-template-literal/convert-to-template-literal.ts
@@ -27,7 +27,7 @@ function updateCode(ast: t.AST, selection: Selection): t.Transformed {
         // Case of <MyComponent prop="test" /> => <MyComponent prop={`test`} />
         path.replaceWith(t.jsxExpressionContainer(templateLiteral));
       } else {
-        path.replaceWith(templateLiteral);
+        t.replaceWithPreservingComments(path, templateLiteral);
       }
 
       path.stop();

--- a/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.test.ts
+++ b/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.test.ts
@@ -104,6 +104,17 @@ getLastName = () => {
         code: `const { firstName, lastName, ...others } = someObject;`,
         expected: `let firstName, lastName, others;
 ({ firstName, lastName, ...others } = someObject);`
+      },
+      {
+        description: "preserves comments",
+        code: `// leading comment
+[cursor]const firstName = "Jane";
+// trailing comment`,
+        expected: `// leading comment
+let firstName;
+
+firstName = "Jane";
+// trailing comment`
       }
     ],
     async ({ code, expected }) => {

--- a/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.ts
+++ b/src/refactorings/split-declaration-and-initialization/split-declaration-and-initialization.ts
@@ -20,7 +20,7 @@ function updateCode(ast: t.AST, selection: Selection): t.Transformed {
     createVisitor(selection, (path: t.NodePath<t.VariableDeclaration>) => {
       const declarations = path.node.declarations;
       const kind = path.node.kind === "const" ? "let" : path.node.kind;
-      path.replaceWithMultiple([
+      t.replaceWithMultiplePreservingComments(path, [
         t.variableDeclaration(
           kind,
           declarations.flatMap(({ id }) => createVariableDeclarators(id))

--- a/src/refactorings/split-multiple-declarations/split-multiple-declarations.test.ts
+++ b/src/refactorings/split-multiple-declarations/split-multiple-declarations.test.ts
@@ -40,6 +40,17 @@ let details = {age: 10, country: "Moon"};`
         code: `let firstName: string = 'John', age: number = 7`,
         expected: `let firstName: string = 'John';
 let age: number = 7;`
+      },
+      {
+        description: "preserves comments",
+        code: `// leading comment
+const x = 1, y = 2;
+// trailing comment`,
+        expected: `// leading comment
+const x = 1;
+
+const y = 2;
+// trailing comment`
       }
     ],
     async ({ code, expected }) => {

--- a/src/refactorings/split-multiple-declarations/split-multiple-declarations.ts
+++ b/src/refactorings/split-multiple-declarations/split-multiple-declarations.ts
@@ -25,7 +25,7 @@ function updateCode(ast: t.AST, selection: Selection): t.Transformed {
         return t.variableDeclaration(kind, [declarator]);
       });
 
-      path.replaceWithMultiple(declarations);
+      t.replaceWithMultiplePreservingComments(path, declarations);
     })
   );
 }


### PR DESCRIPTION
Fixes #705

Some refactorings deleted comments (e.g. `Split multiple declarations`) because `path.replaceWith/replaceWithMultiple` does not inherit the `comments` property added by recast. I fixed this by creating and calling `replaceWithPreservingComments/replaceWithMultiplePreservingComments` instead.