### PR TITLE
Change Signature I: Add contract test for code references

### DIFF
--- a/src/editor/adapters/in-memory-editor.ts
+++ b/src/editor/adapters/in-memory-editor.ts
@@ -243,7 +243,10 @@ export class InMemoryEditor implements Editor {
         references.push(
           new CodeReference(
             obj.filename,
-            new Selection([pos.row, pos.col], [pos.row, pos.col])
+            new Selection(
+              [pos.row, pos.col],
+              [pos.row, pos.col + functionReferences.length]
+            )
           )
         );
       });
@@ -263,19 +266,21 @@ export class InMemoryEditor implements Editor {
     splittedCode.forEach((arr, row) => {
       const word = arr.join("");
       if (word.includes(wordToSearch)) {
-        const post = arr.map((_char, col) => ({
-          word,
-          row: row + 1,
-          col: col + 1
-        }));
+        const post = arr.map((_char, col) => {
+          const nextWord = arr.slice(col, col + wordToSearch.length).join("");
+
+          return {
+            word,
+            row: row + 1,
+            col: nextWord === wordToSearch ? col : -1
+          };
+        });
 
         items.push(...post);
       }
     });
 
-    return items.filter(
-      (v, i, a) => a.findIndex((v2) => v2.word === v.word) === i
-    );
+    return items.filter((item) => item.col !== -1);
   }
 
   async askForPositions(

--- a/src/editor/editor-contract-test.ts
+++ b/src/editor/editor-contract-test.ts
@@ -2,9 +2,10 @@ import { suite, test, afterEach } from "mocha";
 import { assert } from "chai";
 import * as sinon from "sinon";
 
-import { Editor, Code, RelativePath } from "./editor";
+import { Editor, Code, RelativePath, AbsolutePath } from "./editor";
 import { Position } from "./position";
 import { Selection } from "./selection";
+import { CodeReference } from "./code-reference";
 
 /**
  * This is a contract tests factory.
@@ -405,5 +406,27 @@ console.log("hello");
     const result = await editor.workspaceFiles();
 
     assert.sameDeepMembers(result, files);
+  });
+
+  test("should return the list of code references in same file", async () => {
+    const code = `function add(num1, num2) {
+return num1 + num2;
+}
+add(1, 2);
+`;
+    const editor = await createEditorOn(code);
+    const file =
+      __dirname + "/adapters/vscode-editor-tests/abracadabra-vscode-tests.ts";
+    const filePath = new AbsolutePath(file);
+    await editor.writeIn(filePath, code);
+    const codeReferences = await editor.getSelectionReferences(
+      new Selection([0, 9], [0, 9])
+    );
+
+    assert.strictEqual(codeReferences.length, 2);
+    assert.deepStrictEqual(codeReferences, [
+      new CodeReference(new AbsolutePath(file), new Selection([1, 9], [1, 12])),
+      new CodeReference(new AbsolutePath(file), new Selection([4, 0], [4, 3]))
+    ]);
   });
 }


### PR DESCRIPTION
Verify that `getSelectionReferences` behavior is similar to what VS Code and InMemory does

It was pending from https://github.com/nicoespeon/abracadabra/pull/725#discussion_r1009994929