### PR TITLE
Fix "Flip If/Else" that was removing parentheses

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "deploy:ovsx": "ovsx publish"
   },
   "devDependencies": {
-    "@babel/core": "7.18.13",
+    "@babel/core": "7.19.3",
     "@babel/preset-env": "7.19.3",
     "@babel/preset-typescript": "7.18.6",
     "@types/babel__traverse": "7.17.1",
@@ -106,8 +106,8 @@
   },
   "dependencies": {
     "@babel/parser": "7.19.3",
-    "@babel/traverse": "7.18.9",
-    "@babel/types": "7.18.4",
+    "@babel/traverse": "7.19.3",
+    "@babel/types": "7.19.3",
     "@eslint/eslintrc": "1.3.3",
     "@typescript-eslint/parser": "5.38.1",
     "@typescript/vfs": "1.4.0",
@@ -118,12 +118,12 @@
     "minimatch": "5.1.0",
     "pluralize": "8.0.0",
     "react-codemod": "5.4.3",
-    "recast": "0.20.5",
+    "recast": "0.21.5",
     "ts-morph": "12.1.0",
     "typescript": "4.8.4"
   },
   "resolutions": {
-    "@babel/types": "7.18.4"
+    "@babel/types": "7.19.3"
   },
   "activationEvents": [
     "onCommand:abracadabra.addNumericSeparator",

--- a/src/refactorings/create-factory-for-constructor/create-factory-for-constructor.ts
+++ b/src/refactorings/create-factory-for-constructor/create-factory-for-constructor.ts
@@ -1,6 +1,6 @@
+import * as t from "../../ast";
 import { Editor, ErrorReason } from "../../editor/editor";
 import { Selection } from "../../editor/selection";
-import * as t from "../../ast";
 
 export async function createFactoryForConstructor(editor: Editor) {
   const { code, selection } = editor;
@@ -110,6 +110,8 @@ function toArrayExpression(pattern: t.ArrayPattern): t.ArrayExpression {
       ? toObjectExpression(element)
       : t.isAssignmentPattern(element)
       ? assignmentToObjectExpression(element)
+      : t.isTSParameterProperty(element)
+      ? null
       : element;
   });
   return t.arrayExpression(elements);

--- a/src/refactorings/extract-interface/extract-interface.test.ts
+++ b/src/refactorings/extract-interface/extract-interface.test.ts
@@ -30,7 +30,7 @@ describe("Extract Interface", () => {
 }
 
 interface Extracted {
-  isEqualTo(position: Position): boolean;
+  isEqualTo(position: Position): boolean
 }`
       },
       {
@@ -47,7 +47,7 @@ interface Extracted {
 }
 
 interface Extracted {
-  isEqualTo(position: {x: number, y: number}): boolean;
+  isEqualTo(position: {x: number, y: number}): boolean
 }`
       },
       {
@@ -64,7 +64,7 @@ interface Extracted {
 }
 
 interface Extracted {
-  isEqualTo(position?: Position): boolean;
+  isEqualTo(position?: Position): boolean
 }`
       },
       {
@@ -87,7 +87,7 @@ interface Extracted {
 }
 
 interface Extracted {
-  isEqualTo(position: Position): boolean;
+  isEqualTo(position: Position): boolean
 }`
       },
       {
@@ -108,11 +108,11 @@ interface Extracted {
 }
 
 interface Extracted {
-  x: number;
-  readonly y: number;
-  isValid: boolean;
-  name: string;
-  someData: any;
+  x: number
+  readonly y: number
+  isValid: boolean
+  name: string
+  someData: any
 }`
       },
       {
@@ -131,7 +131,7 @@ interface Extracted {
 }
 
 interface Extracted {
-  x: number;
+  x: number
 }`
       },
       {
@@ -154,9 +154,9 @@ interface Extracted {
 }
 
 interface Extracted {
-  name: string;
-  readonly isValid: boolean;
-  y: number;
+  name: string
+  readonly isValid: boolean
+  y: number
 }`
       },
       {
@@ -185,7 +185,7 @@ class AnotherPosition implements Extracted {
 }
 
 interface Extracted {
-  isEqualTo(position: Position): boolean;
+  isEqualTo(position: Position): boolean
 }`
       },
       {
@@ -206,8 +206,8 @@ interface Extracted {
 }
 
 interface Extracted {
-  readonly numbers: number[];
-  bar(): number;
+  readonly numbers: number[]
+  bar(): number
 }`
       },
       {
@@ -228,8 +228,8 @@ interface Extracted {
 }
 
 interface Extracted {
-  readonly numbers: number[];
-  bar(): number;
+  readonly numbers: number[]
+  bar(): number
 }`
       },
       {
@@ -242,7 +242,7 @@ interface Extracted {
 }
 
 interface Extracted<T extends string> {
-  readonly items: T[];
+  readonly items: T[]
 }`
       },
       {
@@ -267,7 +267,7 @@ interface Extracted<T extends string> {
 }
 
 interface Extracted {
-  isEqualTo(position: Position): boolean;
+  isEqualTo(position: Position): boolean
 }`
       },
       {
@@ -293,9 +293,9 @@ interface Extracted {
 
 interface Extracted {
   /* TODO: add the missing return type */
-  isEqualTo(position: Position): any;
+  isEqualTo(position: Position): any
   /* TODO: add the missing return type */
-  fetch(): Promise<any>;
+  fetch(): Promise<any>
 }`
       }
     ],

--- a/src/refactorings/extract/extract-type/extract-type.test.ts
+++ b/src/refactorings/extract/extract-type/extract-type.test.ts
@@ -77,7 +77,7 @@ let something: { response: Extracted };`
         description: "as expression",
         code: `console.log(person as [cursor]{ name: string });`,
         expected: `interface [cursor]Extracted {
-  name: string;
+  name: string
 }
 
 console.log(person as Extracted);`
@@ -130,9 +130,9 @@ const someMachine = createMachine<C<typeof someModel>, Extracted>()`
         description: "object type using commas",
         code: `function doSomething(options: { first: number, second: boolean, third: string }[cursor]) {}`,
         expected: `interface Extracted {
-  first: number;
-  second: boolean;
-  third: string;
+  first: number,
+  second: boolean,
+  third: string
 }
 
 function doSomething(options: Extracted) {}`

--- a/src/refactorings/extract/extract-type/extract-type.ts
+++ b/src/refactorings/extract/extract-type/extract-type.ts
@@ -1,7 +1,7 @@
-import { Command, Editor, ErrorReason } from "../../../editor/editor";
-import { Selection } from "../../../editor/selection";
-import { Position } from "../../../editor/position";
 import * as t from "../../../ast";
+import { Command, Editor, ErrorReason } from "../../../editor/editor";
+import { Position } from "../../../editor/position";
+import { Selection } from "../../../editor/selection";
 
 export async function extractType(editor: Editor) {
   const { code, selection } = editor;
@@ -54,7 +54,7 @@ function updateCode(
 
       const leadingComments = pathWhereToDeclareType.node.leadingComments || [];
       const start =
-        leadingComments[0]?.loc.start || pathWhereToDeclareType.node.loc.start;
+        leadingComments[0]?.loc?.start || pathWhereToDeclareType.node.loc.start;
       newNodePosition = Position.fromAST(start);
       pathWhereToDeclareType.insertBefore(typeDeclaration);
       replaceTypeWith(typeIdentifier);

--- a/src/refactorings/extract/extract-variable/occurrence.ts
+++ b/src/refactorings/extract/extract-variable/occurrence.ts
@@ -162,9 +162,9 @@ export class Occurrence<T extends t.Node = t.Node> {
     const parent = parentPath ? parentPath.node : this.path.node;
     if (!parent.loc) return this.selection.start;
 
-    const firstLeadingComment = parent.leadingComments?.[0];
-    return firstLeadingComment
-      ? Position.fromAST(firstLeadingComment.loc.start)
+    const firstLeadingCommentLoc = parent.leadingComments?.[0]?.loc;
+    return firstLeadingCommentLoc
+      ? Position.fromAST(firstLeadingCommentLoc.start)
       : Position.fromAST(parent.loc.start);
   }
 

--- a/src/refactorings/flip-if-else/flip-if-else.test.ts
+++ b/src/refactorings/flip-if-else/flip-if-else.test.ts
@@ -1,5 +1,5 @@
-import { Code, ErrorReason } from "../../editor/editor";
 import { InMemoryEditor } from "../../editor/adapters/in-memory-editor";
+import { Code, ErrorReason } from "../../editor/editor";
 import { testEach } from "../../tests-helpers";
 
 import { flipIfElse } from "./flip-if-else";
@@ -255,6 +255,19 @@ doSomethingElse();`,
   doAnotherThing();
 } else {
   doSomething();
+}`
+      },
+      {
+        description: "preserve parentheses",
+        code: `if (false && (false || true)) {
+  console.log('true');
+} else {
+  console.log('false');
+}`,
+        expected: `if (!(false && (false || true))) {
+  console.log('false');
+} else {
+  console.log('true');
 }`
       }
     ],

--- a/src/refactorings/flip-if-else/flip-if-else.ts
+++ b/src/refactorings/flip-if-else/flip-if-else.ts
@@ -154,5 +154,5 @@ function getNegatedIfTest(test: t.IfStatement["test"]): t.IfStatement["test"] {
     };
   }
 
-  return t.unaryExpression("!", test, true);
+  return t.unaryExpression("!", test);
 }

--- a/src/refactorings/flip-operator/flip-operator.test.ts
+++ b/src/refactorings/flip-operator/flip-operator.test.ts
@@ -66,7 +66,7 @@ describe("Flip Operator", () => {
       {
         description: "nested logical or, cursor on wrapper",
         code: "a [cursor]&& (b || c)",
-        expected: "b || c && (a)"
+        expected: "(b || c) && (a)"
       }
     ],
     async ({ code, expected }) => {

--- a/src/refactorings/move-statement-up/move-statement-up.ts
+++ b/src/refactorings/move-statement-up/move-statement-up.ts
@@ -1,7 +1,7 @@
-import { Editor, Code, ErrorReason } from "../../editor/editor";
-import { Selection } from "../../editor/selection";
-import { Position } from "../../editor/position";
 import * as t from "../../ast";
+import { Code, Editor, ErrorReason } from "../../editor/editor";
+import { Position } from "../../editor/position";
+import { Selection } from "../../editor/selection";
 
 export async function moveStatementUp(editor: Editor) {
   const { code, selection } = editor;
@@ -92,6 +92,7 @@ function updateCode(
 
     if (hasComments(path)) {
       path.node.leadingComments.forEach((comment) => {
+        if (!comment.loc) return;
         const { height } = Selection.fromAST(comment.loc);
         newStatementPosition = newStatementPosition.addLines(height + 1);
       });
@@ -99,6 +100,7 @@ function updateCode(
 
     if (hasComments(pathAbove)) {
       pathAbove.node.leadingComments.forEach((comment) => {
+        if (!comment.loc) return;
         const { height } = Selection.fromAST(comment.loc);
         newStatementPosition = newStatementPosition.removeLines(height + 1);
       });

--- a/src/refactorings/react/extract-use-callback/extract-use-callback.test.ts
+++ b/src/refactorings/react/extract-use-callback/extract-use-callback.test.ts
@@ -35,7 +35,7 @@ function Bar() {
     console.log(e);
   }, []);
 
-  return <Foo onFoo={onFoo} />;
+  return (<Foo onFoo={onFoo} />);
 }`
       },
       {

--- a/src/refactorings/split-if-statement/split-if-statement.test.ts
+++ b/src/refactorings/split-if-statement/split-if-statement.test.ts
@@ -47,7 +47,7 @@ describe("Split If Statement", () => {
   doSomething();
 }`,
         expected: `if (isValid) {
-  if (isCorrect || shouldDoSomething) {
+  if ((isCorrect || shouldDoSomething)) {
     doSomething();
   }
 }`

--- a/src/refactorings/toggle-braces/toggle-braces.test.ts
+++ b/src/refactorings/toggle-braces/toggle-braces.test.ts
@@ -123,9 +123,9 @@ if (isValid) {
 }`,
         expected: `function TestComponent() {
   return (
-    <section>
+    (<section>
       <TestComponent testProp={"test"} />
-    </section>
+    </section>)
   );
 }`
       },
@@ -392,9 +392,9 @@ doAnotherThing();`
 }`,
         expected: `function TestComponent() {
   return (
-    <section>
+    (<section>
       <TestComponent testProp="test" />
-    </section>
+    </section>)
   );
 }`
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,7 +21,28 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.19.3.tgz#707b939793f867f5a73b2666e6d9a3396eb03151"
   integrity sha512-prBHMK4JYYK+wDjJF1q99KK4JLL+egWS4nmNqdlMUgCExMZ+iZW0hGhyC3VEbsPjvaN0TBhW//VIFwBrk8sEiw==
 
-"@babel/core@7.18.13", "@babel/core@^7.1.0", "@babel/core@^7.1.6", "@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.7.2", "@babel/core@^7.8.0":
+"@babel/core@7.19.3":
+  version "7.19.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.19.3.tgz#2519f62a51458f43b682d61583c3810e7dcee64c"
+  integrity sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==
+  dependencies:
+    "@ampproject/remapping" "^2.1.0"
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.19.3"
+    "@babel/helper-compilation-targets" "^7.19.3"
+    "@babel/helper-module-transforms" "^7.19.0"
+    "@babel/helpers" "^7.19.0"
+    "@babel/parser" "^7.19.3"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.19.3"
+    "@babel/types" "^7.19.3"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.1"
+    semver "^6.3.0"
+
+"@babel/core@^7.1.0", "@babel/core@^7.1.6", "@babel/core@^7.12.3", "@babel/core@^7.13.16", "@babel/core@^7.7.2", "@babel/core@^7.8.0":
   version "7.18.13"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.13.tgz#9be8c44512751b05094a4d3ab05fc53a47ce00ac"
   integrity sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==
@@ -42,7 +63,7 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/generator@^7.18.13", "@babel/generator@^7.18.9", "@babel/generator@^7.7.2":
+"@babel/generator@^7.18.13", "@babel/generator@^7.7.2":
   version "7.18.13"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.13.tgz#59550cbb9ae79b8def15587bdfbaa388c4abf212"
   integrity sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==
@@ -57,6 +78,15 @@
   integrity sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==
   dependencies:
     "@babel/types" "^7.19.3"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
+"@babel/generator@^7.20.1":
+  version "7.20.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.4.tgz#4d9f8f0c30be75fd90a0562099a26e5839602ab8"
+  integrity sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==
+  dependencies:
+    "@babel/types" "^7.20.2"
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
@@ -285,15 +315,20 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-validator-identifier@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
-  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+"@babel/helper-string-parser@^7.18.10":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
+  integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
 
 "@babel/helper-validator-identifier@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
   integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
+
+"@babel/helper-validator-identifier@^7.19.1":
+  version "7.19.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz#7eea834cf32901ffdc1a7ee555e2f9c27e249ca2"
+  integrity sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==
 
 "@babel/helper-validator-option@^7.14.5", "@babel/helper-validator-option@^7.18.6":
   version "7.18.6"
@@ -329,6 +364,15 @@
     "@babel/traverse" "^7.18.9"
     "@babel/types" "^7.18.9"
 
+"@babel/helpers@^7.19.0":
+  version "7.20.1"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.1.tgz#2ab7a0fcb0a03b5bf76629196ed63c2d7311f4c9"
+  integrity sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==
+  dependencies:
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.20.1"
+    "@babel/types" "^7.20.0"
+
 "@babel/highlight@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
@@ -338,10 +382,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.19.3", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.13.16", "@babel/parser@^7.14.7", "@babel/parser@^7.18.10", "@babel/parser@^7.18.13", "@babel/parser@^7.18.9", "@babel/parser@^7.19.3":
+"@babel/parser@7.19.3", "@babel/parser@^7.1.0", "@babel/parser@^7.1.6", "@babel/parser@^7.13.16", "@babel/parser@^7.14.7", "@babel/parser@^7.18.10", "@babel/parser@^7.18.13", "@babel/parser@^7.19.3":
   version "7.19.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.3.tgz#8dd36d17c53ff347f9e55c328710321b49479a9a"
   integrity sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==
+
+"@babel/parser@^7.20.1":
+  version "7.20.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.3.tgz#5358cf62e380cf69efcb87a7bb922ff88bfac6e2"
+  integrity sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1076,19 +1125,19 @@
     "@babel/parser" "^7.18.10"
     "@babel/types" "^7.18.10"
 
-"@babel/traverse@7.18.9":
-  version "7.18.9"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.9.tgz#deeff3e8f1bad9786874cb2feda7a2d77a904f98"
-  integrity sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==
+"@babel/traverse@7.19.3", "@babel/traverse@^7.19.0":
+  version "7.19.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.19.3.tgz#3a3c5348d4988ba60884e8494b0592b2f15a04b4"
+  integrity sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==
   dependencies:
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.18.9"
+    "@babel/generator" "^7.19.3"
     "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
     "@babel/helper-hoist-variables" "^7.18.6"
     "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.18.9"
-    "@babel/types" "^7.18.9"
+    "@babel/parser" "^7.19.3"
+    "@babel/types" "^7.19.3"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -1108,28 +1157,29 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.19.0":
-  version "7.19.3"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.19.3.tgz#3a3c5348d4988ba60884e8494b0592b2f15a04b4"
-  integrity sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==
+"@babel/traverse@^7.19.3", "@babel/traverse@^7.20.1":
+  version "7.20.1"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.1.tgz#9b15ccbf882f6d107eeeecf263fbcdd208777ec8"
+  integrity sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==
   dependencies:
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.19.3"
+    "@babel/generator" "^7.20.1"
     "@babel/helper-environment-visitor" "^7.18.9"
     "@babel/helper-function-name" "^7.19.0"
     "@babel/helper-hoist-variables" "^7.18.6"
     "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.19.3"
-    "@babel/types" "^7.19.3"
+    "@babel/parser" "^7.20.1"
+    "@babel/types" "^7.20.0"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@7.18.4", "@babel/types@^7.0.0", "@babel/types@^7.18.10", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.19.3", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
-  version "7.18.4"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.4.tgz#27eae9b9fd18e9dccc3f9d6ad051336f307be354"
-  integrity sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==
+"@babel/types@7.19.3", "@babel/types@^7.0.0", "@babel/types@^7.18.10", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.19.3", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
+  version "7.19.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.3.tgz#fc420e6bbe54880bce6779ffaf315f5e43ec9624"
+  integrity sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
+    "@babel/helper-string-parser" "^7.18.10"
+    "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
 "@bcoe/v8-coverage@^0.2.3":
@@ -2262,6 +2312,13 @@ ast-types@0.14.2, ast-types@^0.14.1:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
   integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
+  dependencies:
+    tslib "^2.0.1"
+
+ast-types@0.15.2:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.15.2.tgz#39ae4809393c4b16df751ee563411423e85fb49d"
+  integrity sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==
   dependencies:
     tslib "^2.0.1"
 
@@ -7033,7 +7090,17 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-recast@0.20.5, recast@^0.20.3, recast@^0.20.4:
+recast@0.21.5:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.21.5.tgz#e8cd22bb51bcd6130e54f87955d33a2b2e57b495"
+  integrity sha512-hjMmLaUXAm1hIuTqOdeYObMslq/q+Xff6QE3Y2P+uoHAg2nmVlLBps2hzh1UJDdMtDTMXOFewK6ky51JQIeECg==
+  dependencies:
+    ast-types "0.15.2"
+    esprima "~4.0.0"
+    source-map "~0.6.1"
+    tslib "^2.0.1"
+
+recast@^0.20.3, recast@^0.20.4:
   version "0.20.5"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.20.5.tgz#8e2c6c96827a1b339c634dd232957d230553ceae"
   integrity sha512-E5qICoPoNL4yU0H0NoBDntNB0Q5oMSNh9usFctYniLBluTthi3RsQVBXIJNbApOlvSwW/RGxIuokPcAc59J5fQ==


### PR DESCRIPTION
Turns out this was an issue with Recast. Upgrading the dependencies fixed that.

I added a test to capture this scenario. I noticed this change may add new parens that are not necessarily required, but that's less important than having broken code (if you have Prettier, they will be auto-trimmed).

Close #753