### PR TITLE
Do not show 'Change signature' quick fix when a function/method does not has parameters

### DIFF
--- a/src/refactorings/change-signature/change-signature.ts
+++ b/src/refactorings/change-signature/change-signature.ts
@@ -158,10 +158,14 @@ export function createVisitor(
     FunctionDeclaration(path) {
       if (!selection.isInsidePath(path)) return;
 
+      if (!hasParameters(path.node)) return;
+
       onMatch(path, selection);
     },
     ArrowFunctionExpression(path) {
       if (!selection.isInsidePath(path)) return;
+
+      if (!hasParameters(path.node)) return;
 
       if (!t.isVariableDeclarator(path.parent)) return;
 
@@ -171,6 +175,9 @@ export function createVisitor(
     },
     ClassMethod(path) {
       if (!selection.isInsidePath(path)) return;
+
+      if (!hasParameters(path.node)) return;
+
       onMatch(path, selection);
     }
   };
@@ -250,4 +257,10 @@ function createVisitorForReferences(
       onMatch(path);
     }
   };
+}
+
+function hasParameters(
+  node: t.FunctionDeclaration | t.ArrowFunctionExpression | t.ClassMethod
+) {
+  return node.params.length > 0;
 }


### PR DESCRIPTION
Hide "Change signature" for function/method without parameters

Error:
![image](https://user-images.githubusercontent.com/8685132/205508512-9fab4315-b9aa-48ae-8af4-2e8d1b74dec0.png)
![image](https://user-images.githubusercontent.com/8685132/205508529-f6151ce0-4045-4d96-8943-b55f0f28ec04.png)

New:

![image](https://user-images.githubusercontent.com/8685132/205508603-cb43083a-c34f-4d7e-ac47-6d73ea6be098.png)
![image](https://user-images.githubusercontent.com/8685132/205508618-bc10d3a2-a3d2-45e3-9af5-82f4fe5d3d8e.png)

Even for React Components

Error:
![image](https://user-images.githubusercontent.com/8685132/205508760-d644f421-7b74-41fe-a980-ce795b9ddc74.png)

New
![image](https://user-images.githubusercontent.com/8685132/205508692-17105ede-0f34-4441-8c54-03d14389537f.png)
