### PR TITLE
Add `Wrap in JSX fragment` refactoring

### DIFF
--- a/package.json
+++ b/package.json
@@ -344,6 +344,11 @@
         "command": "abracadabra.removeAllHighlights",
         "title": "Remove All Highlights",
         "category": "Abracadabra"
+      },
+      {
+        "command": "abracadabra.wrapInJsxFragment",
+        "title": "Wrap in JSX Fragment",
+        "category": "Abracadabra"
       }
     ],
     "keybindings": [
@@ -1464,6 +1469,14 @@
         {
           "command": "abracadabra.toggleBraces",
           "when": "editorLangId == svelte"
+        },
+        {
+          "command": "abracadabra.wrapInJSXFragment",
+          "when": "editorLangId == javascriptreact"
+        },
+        {
+          "command": "abracadabra.wrapInJSXFragment",
+          "when": "editorLangId == typescriptreact"
         }
       ]
     }

--- a/src/editor/error-reason.ts
+++ b/src/editor/error-reason.ts
@@ -1,4 +1,5 @@
 export enum ErrorReason {
+  CouldNotWrapInJsxFragment,
   DidNotFindOperatorToFlip,
   CantChangeSignature,
   DidNotFindClass,
@@ -61,6 +62,9 @@ export enum ErrorReason {
 
 export function toString(reason: ErrorReason): string {
   switch (reason) {
+    case ErrorReason.CouldNotWrapInJsxFragment:
+      return didNotFind("something to wrap in a jsx fragment");
+
     case ErrorReason.DidNotFindOperatorToFlip:
       return didNotFind("an operator to flip");
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,11 @@
 import * as vscode from "vscode";
+
 import { RefactoringActionProvider } from "./action-providers";
 import { createCommand } from "./commands";
 import { VSCodeEditor } from "./editor/adapters/vscode-editor";
 import refreshHighlights from "./highlights/refresh-highlights";
 import removeAllHighlights from "./highlights/remove-all-highlights";
 import toggleHighlight from "./highlights/toggle-highlight";
-import { Refactoring, RefactoringWithActionProvider } from "./types";
-
 import addNumericSeparator from "./refactorings/add-numeric-separator";
 import changeSignature from "./refactorings/change-signature";
 import convertForEachToForOf from "./refactorings/convert-for-each-to-for-of";
@@ -49,6 +48,8 @@ import splitDeclarationAndInitialization from "./refactorings/split-declaration-
 import splitIfStatement from "./refactorings/split-if-statement";
 import splitMultipleDeclarations from "./refactorings/split-multiple-declarations";
 import toggleBraces from "./refactorings/toggle-braces";
+import wrapInJsxFrament from "./refactorings/wrap-in-jsx-fragment";
+import { Refactoring, RefactoringWithActionProvider } from "./types";
 
 const refactorings: { [key: string]: ConfiguredRefactoring } = {
   typescriptOnly: {
@@ -58,7 +59,7 @@ const refactorings: { [key: string]: ConfiguredRefactoring } = {
   },
   reactOnly: {
     languages: ["javascriptreact", "typescriptreact"],
-    withoutActionProvider: [reactConvertToPureComponent],
+    withoutActionProvider: [reactConvertToPureComponent, wrapInJsxFrament],
     withActionProvider: [reactExtractUseCallback]
   },
   allButVueAndSvelte: {

--- a/src/refactorings/wrap-in-jsx-fragment/index.ts
+++ b/src/refactorings/wrap-in-jsx-fragment/index.ts
@@ -1,0 +1,11 @@
+import { Refactoring } from "../../types";
+import { wrapInJsxFragment } from "./wrap-in-jsx-fragment";
+
+const config: Refactoring = {
+  command: {
+    key: "wrapInJsxFragment",
+    operation: wrapInJsxFragment
+  }
+};
+
+export default config;

--- a/src/refactorings/wrap-in-jsx-fragment/wrap-in-jsx-fragment.test.ts
+++ b/src/refactorings/wrap-in-jsx-fragment/wrap-in-jsx-fragment.test.ts
@@ -1,0 +1,33 @@
+import { ErrorReason, Code } from "../../editor/editor";
+import { InMemoryEditor } from "../../editor/adapters/in-memory-editor";
+import { testEach } from "../../tests-helpers";
+
+import { wrapInJsxFragment } from "./wrap-in-jsx-fragment";
+
+describe("Wrap In Jsx Fragment", () => {
+  testEach<{ code: Code; expected: Code }>(
+    "should wrap in jsx fragment",
+    [
+      // TODO: write successful test cases here
+    ],
+    async ({ code, expected }) => {
+      const editor = new InMemoryEditor(code);
+
+      await wrapInJsxFragment(editor);
+
+      expect(editor.code).toBe(expected);
+    }
+  );
+
+  it("should show an error message if refactoring can't be made", async () => {
+    const code = `// This is a comment, can't be refactored`;
+    const editor = new InMemoryEditor(code);
+    jest.spyOn(editor, "showError");
+
+    await wrapInJsxFragment(editor);
+
+    expect(editor.showError).toBeCalledWith(
+      ErrorReason.CouldNotWrapInJsxFragment
+    );
+  });
+});

--- a/src/refactorings/wrap-in-jsx-fragment/wrap-in-jsx-fragment.ts
+++ b/src/refactorings/wrap-in-jsx-fragment/wrap-in-jsx-fragment.ts
@@ -1,0 +1,46 @@
+import * as t from "../../ast";
+import { Editor, ErrorReason } from "../../editor/editor";
+import { Selection } from "../../editor/selection";
+
+export async function wrapInJsxFragment(editor: Editor) {
+  const { code, selection } = editor;
+  const updatedCode = updateCode(t.parse(code), selection);
+
+  if (!updatedCode.hasCodeChanged) {
+    editor.showError(ErrorReason.CouldNotWrapInJsxFragment);
+    return;
+  }
+
+  await editor.write(updatedCode.code);
+}
+
+function updateCode(ast: t.AST, selection: Selection): t.Transformed {
+  return t.transformAST(
+    ast,
+    createVisitor(selection, (path, node) => {
+      // TODO: implement the transformation here 🧙‍
+      t.replaceWithPreservingComments(path, node);
+      path.stop();
+    })
+  );
+}
+
+export function createVisitor(
+  selection: Selection,
+  onMatch: (path: t.NodePath, node: t.Node) => void
+): t.Visitor {
+  // TODO: implement the check here 🧙‍
+  return {
+    JSXElement(path) {
+      if (!selection.isInsidePath(path)) return;
+
+      const fragment = t.jsxFragment(
+        t.jsxOpeningFragment(),
+        t.jsxClosingFragment(),
+        [path.node]
+      );
+      path.replaceWith(fragment);
+      onMatch(path, path.node);
+    }
+  };
+}


### PR DESCRIPTION
Hi everyone!
Thanks for this awesome extension, just the right amount of magic a developer needs 🪄 

This PR will, once finished, add a refactoring that wraps the selection in a `JSX fragment` if it is a JSX element.
Before:
```jsx
return <div>Something witty goes here</div>;
```
After:
```jsx
return (
  <>
    <div>Something witty goes here</div>
  </>
);
```

### Still Todo:
- [ ] write tests
- [ ] adding the parentheses not yet working as intended


Closes #791 
