### PR TITLE
Automatically trigger "Convert to Template Literal"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - When triggering a refactoring from a quick fix (the 💡 icon), Abracadabra will use the code and position you were on when the fix was suggested. This should be invisible for most use-case, but will play nicely with extensions like [cursorless](https://marketplace.visualstudio.com/items?itemName=pokey.cursorless). Thanks @jaresty for reporting, and @pokey for adding more context 😉
+- "Convert to Template String" will now preserve `${}` and `${someValue}` as-is, without escaping it. It's technically a bug (= changes the behavior of the code) but usage indicates these are meant to become interpolated variables. So it's more likely to do what you want.
 
 ## [9.1.3]
 

--- a/README.md
+++ b/README.md
@@ -97,12 +97,13 @@ That's why you have a "Refresh Highlights" command. Hit `Shift + Alt + H` and re
 
 ## Configuration
 
-| Setting                         | Description                                                                          | Default                 |
-| ------------------------------- | ------------------------------------------------------------------------------------ | ----------------------- |
-| `abracadabra.ignoredFolders`    | Folders where it won't propose refactorings                                          | `["node_modules"]`      |
-| `abracadabra.ignoredPatterns`   | Glob patterns where it won't propose refactorings                                    | `["dist/*", "build/*"]` |
-| `abracadabra.maxFileLinesCount` | Don't propose refactorings on files that have more lines of code than this threshold | `10.000`                |
-| `abracadabra.getMaxFileSizeKb`  | Don't propose refactorings on files that bigger than this threshold (in kB)          | `250`                   |
+| Setting                                    | Description                                                                          | Default                 |
+| ------------------------------------------ | ------------------------------------------------------------------------------------ | ----------------------- |
+| `abracadabra.ignoredFolders`               | Folders where it won't propose refactorings                                          | `["node_modules"]`      |
+| `abracadabra.ignoredPatterns`              | Glob patterns where it won't propose refactorings                                    | `["dist/*", "build/*"]` |
+| `abracadabra.maxFileLinesCount`            | Don't propose refactorings on files that have more lines of code than this threshold | `10.000`                |
+| `abracadabra.getMaxFileSizeKb`             | Don't propose refactorings on files that bigger than this threshold (in kB)          | `250`                   |
+| `abracadabra.autoConvertToTemplateLiteral` | Automatically convert a string into a template literal when you insert `${}`         | `true`                  |
 
 For the glob patterns, read [glob's documentation](https://github.com/isaacs/node-glob/blob/f5a57d3d6e19b324522a3fa5bdd5075fd1aa79d1/README.md#glob-primer) to see what you can filter out.
 

--- a/REFACTORINGS.md
+++ b/REFACTORINGS.md
@@ -441,6 +441,10 @@ Hence, Abracadabra is proposing the refactoring for such scenario!
 
 ![][demo-convert-to-template-literal]
 
+By default, this refactoring will automatically apply if you write `${}` in a string literal. This is convenient behavior in most scenarios, but technically changes code behaviour.
+
+If you want to disable the automatic transformation, you can turn OFF `abracadabra.autoConvertToTemplateLiteral` in [VS Code settings][vscode-settings].
+
 [⬆️ Go to Table of Contents](#table-of-contents)
 
 ### Replace Binary with Assignment

--- a/package.json
+++ b/package.json
@@ -399,6 +399,11 @@
           "default": 250,
           "description": "Don't propose refactorings on files that are bigger than this threshold (kB)."
         },
+        "abracadabra.autoConvertToTemplateLiteral": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically convert a string into a template literal when you insert `${}`."
+        },
         "abracadabra.addNumericSeparator.showInQuickFix": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "@babel/types": "7.20.7",
     "minimatch": "9.0.3",
     "pluralize": "8.0.0",
-    "recast": "0.23.4"
+    "recast": "0.23.4",
+    "ts-pattern": "5.1.1"
   },
   "activationEvents": [
     "onLanguage:javascript",

--- a/src/editor/adapters/vscode-editor.ts
+++ b/src/editor/adapters/vscode-editor.ts
@@ -398,7 +398,7 @@ function createSourceChanges(
   ];
 }
 
-function createSelectionFromVSCode(
+export function createSelectionFromVSCode(
   selection: vscode.Selection | vscode.Range
 ): Selection {
   return new Selection(

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -71,3 +71,9 @@ export type SelectedPosition = Omit<
   }>,
   "description" | "icon"
 >;
+
+export type CodeChange =
+  | { type: "add"; offset: number; text: string }
+  | { type: "delete"; offset: number; length: number }
+  | { type: "update"; offset: number; length: number; text: string };
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,8 @@ import { RefactoringActionProvider } from "./action-providers";
 import { createCommand } from "./commands";
 import {
   VSCodeEditor,
-  createSelectionFromVSCode
+  createSelectionFromVSCode,
+  getCodeChangeFromVSCode
 } from "./editor/adapters/vscode-editor";
 import refreshHighlights from "./highlights/refresh-highlights";
 import removeAllHighlights from "./highlights/remove-all-highlights";
@@ -179,9 +180,8 @@ export function activate(context: vscode.ExtensionContext) {
 
     if (event.document !== activeTextEditor.document) return;
 
-    const hasAddsOrUpdates = event.contentChanges.some(
-      (change) => change.text.length > 0
-    );
+    const changes = event.contentChanges.map(getCodeChangeFromVSCode);
+    const hasAddsOrUpdates = changes.some((change) => change.type !== "delete");
     if (!hasAddsOrUpdates) return;
 
     const code = activeTextEditor.document.getText();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -169,9 +169,9 @@ export function activate(context: vscode.ExtensionContext) {
     VSCodeEditor.repositionHighlights(event);
 
     const activeTextEditor = vscode.window.activeTextEditor;
-    if (activeTextEditor) {
-      VSCodeEditor.restoreHighlightDecorations(activeTextEditor);
-    }
+    if (!activeTextEditor) return;
+
+    VSCodeEditor.restoreHighlightDecorations(activeTextEditor);
   });
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -186,7 +186,13 @@ export function activate(context: vscode.ExtensionContext) {
 
     const code = activeTextEditor.document.getText();
     const selection = createSelectionFromVSCode(activeTextEditor.selection);
-    if (isInsertingVariableInStringLiteral(code, selection)) {
+
+    const canAutoConvert =
+      vscode.workspace
+        .getConfiguration("abracadabra")
+        .get("autoConvertToTemplateLiteral") === true;
+
+    if (canAutoConvert && isInsertingVariableInStringLiteral(code, selection)) {
       vscode.commands.executeCommand(
         `abracadabra.${convertToTemplateLiteral.command.key}`
       );

--- a/src/refactorings/convert-to-template-literal/convert-to-template-literal.test.ts
+++ b/src/refactorings/convert-to-template-literal/convert-to-template-literal.test.ts
@@ -66,13 +66,23 @@ const lastName = "Doe";`
         expected: "const a = `Hello \\`you\\``"
       },
       {
+        description: "string literal with ${value}",
+        code: "const a = 'Hello[cursor] ${you} ${me2}'",
+        expected: "const a = `Hello ${you} ${me2}`"
+      },
+      {
+        description: "string literal with empty ${}",
+        code: "const a = 'Hello[cursor] ${}'",
+        expected: "const a = `Hello ${}`"
+      },
+      {
         description: "preserves comments",
-        code: `const name = 
+        code: `const name =
   // leading comment
   [cursor]"Jane"
   // trailing comment
   ;`,
-        expected: `const name = 
+        expected: `const name =
   // leading comment
   \`Jane\`
   // trailing comment
@@ -117,6 +127,20 @@ const lastName = "Doe";`
       expect(editor.code).toBe(originalCode);
     }
   );
+
+  it("should preserve cursor position when it converts a JSX prop", async () => {
+    const editor = new InMemoryEditor(
+      `<TestComponent testProp="t[cursor]est" />`
+    );
+
+    await convertToTemplateLiteral(editor);
+
+    const expectedEditor = new InMemoryEditor(
+      `<TestComponent testProp={\`t[cursor]est\`} />`
+    );
+    expect(editor.code).toBe(expectedEditor.code);
+    expect(editor.selection).toEqual(expectedEditor.selection);
+  });
 
   it("should show an error message if refactoring can't be made", async () => {
     const code = `// This is a comment, can't be refactored`;

--- a/src/refactorings/convert-to-template-literal/convert-to-template-literal.ts
+++ b/src/refactorings/convert-to-template-literal/convert-to-template-literal.ts
@@ -1,4 +1,4 @@
-import { Editor, ErrorReason } from "../../editor/editor";
+import { Code, Editor, ErrorReason } from "../../editor/editor";
 import { Position } from "../../editor/position";
 import { Selection } from "../../editor/selection";
 import * as t from "../../ast";
@@ -66,4 +66,26 @@ export function createVisitor(
       onMatch(path);
     }
   };
+}
+
+export function isInsertingVariableInStringLiteral(
+  code: Code,
+  selection: Selection
+): boolean {
+  const lines = code.split("\n");
+  const currentLine = lines[selection.start.line] ?? "";
+  const previous2Chars =
+    currentLine[selection.start.character - 2] +
+    currentLine[selection.start.character - 1];
+  if (previous2Chars !== "${") return false;
+
+  const nextChar = currentLine[selection.start.character];
+  if (nextChar !== "}") return false;
+
+  let result = false;
+  t.traverseAST(
+    t.parse(code),
+    createVisitor(selection, () => (result = true))
+  );
+  return result;
 }

--- a/src/refactorings/convert-to-template-literal/convert-to-template-literal.ts
+++ b/src/refactorings/convert-to-template-literal/convert-to-template-literal.ts
@@ -1,4 +1,5 @@
 import { Editor, ErrorReason } from "../../editor/editor";
+import { Position } from "../../editor/position";
 import { Selection } from "../../editor/selection";
 import * as t from "../../ast";
 
@@ -11,21 +12,32 @@ export async function convertToTemplateLiteral(editor: Editor) {
     return;
   }
 
-  await editor.write(updatedCode.code);
+  const newCode = updatedCode.code.replace(/\$\\{(\w*)}/g, "${$1}");
+  await editor.write(newCode);
+  await editor.moveCursorTo(updatedCode.newCursorPosition);
 }
 
-function updateCode(ast: t.AST, selection: Selection): t.Transformed {
-  return t.transformAST(
+function updateCode(
+  ast: t.AST,
+  selection: Selection
+): t.Transformed & { newCursorPosition: Position } {
+  let newCursorPosition = selection.start;
+
+  const transformedCode = t.transformAST(
     ast,
     createVisitor(selection, (path) => {
+      const sanitizedValue = path.node.value
+        .replace(/`/g, "\\`")
+        .replace(/{/g, "\\{");
       const templateLiteral = t.templateLiteral(
-        [t.templateElement(path.node.value.replace(/`/g, "\\`"))],
+        [t.templateElement(sanitizedValue)],
         []
       );
 
       if (t.isJSXAttribute(path.parentPath)) {
         // Case of <MyComponent prop="test" /> => <MyComponent prop={`test`} />
         path.replaceWith(t.jsxExpressionContainer(templateLiteral));
+        newCursorPosition = newCursorPosition.addCharacters(1);
       } else {
         t.replaceWithPreservingComments(path, templateLiteral);
       }
@@ -33,6 +45,8 @@ function updateCode(ast: t.AST, selection: Selection): t.Transformed {
       path.stop();
     })
   );
+
+  return { ...transformedCode, newCursorPosition };
 }
 
 export function createVisitor(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7001,7 +7001,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7018,15 +7018,6 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
@@ -7085,7 +7076,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7098,13 +7089,6 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -7340,6 +7324,11 @@ ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+
+ts-pattern@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/ts-pattern/-/ts-pattern-5.1.1.tgz#600e0a3d23ab1b0eb30b7c897d0898e940504544"
+  integrity sha512-i+owkHr5RYdQxj8olUgRrqpiWH9x27PuWVfXwDmJ/n/CoF/SAa7WW1i2oUpPDMQpJ4U+bGRUcZkVq7i1m3zFCg==
 
 tslib@^1.9.0:
   version "1.13.0"
@@ -7768,7 +7757,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -7781,15 +7770,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
When adding `${}` in a valid String literal.

It can be disabled in the settings (`abracadabra.autoConvertToTemplateLiteral`) because it's technically not a refactoring—but in most scenarios, this is what we want to do.

It does not handle multi-cursors because the original refactoring doesn't (in fact, none of the refactorings we have support this for now). I think that's OK.

I was considering handling more scenarios, like adding $ to `{someValue}` in a string would also trigger the refactoring… but these don't seem to be the main use-case and may not actually be desirable (again, technically we are modifying the behavior of the code here). So I rollback and stick to the basic one: 

https://github.com/nicoespeon/abracadabra/assets/1094774/476e4755-551c-4446-aa8d-e4552626528e

As usual, I'll iterate based on reported issues, suggestions, and personal usage of this feature 😄

Fixes #1012


