### PR TITLE
Upgrade Node to v20

### DIFF
--- a/.github/workflows/ovsx-deploy.yml
+++ b/.github/workflows/ovsx-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 20.0.0
+          node-version: 22.0.0
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/.github/workflows/ovsx-deploy.yml
+++ b/.github/workflows/ovsx-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18.0.0
+          node-version: 20.0.0
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 20.0.0
+          node-version: 22.0.0
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18.0.0
+          node-version: 20.0.0
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/.github/workflows/vscode-deploy.yml
+++ b/.github/workflows/vscode-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 20.0.0
+          node-version: 22.0.0
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/.github/workflows/vscode-deploy.yml
+++ b/.github/workflows/vscode-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18.0.0
+          node-version: 20.0.0
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "engines": {
     "vscode": ">=1.90.0",
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "main": "./out/extension.js",
   "browser": "./out/extension-browser.js",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "engines": {
     "vscode": ">=1.90.0",
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "main": "./out/extension.js",
   "browser": "./out/extension-browser.js",


### PR DESCRIPTION
Dependencies updates start failing because we rely on Node 18 that will be EOL in less than a year. Let's upgrade to Node 20 at least, or see if we could push to Node 22 (the current version).