### PR TITLE
chore: add Prettier plugin to workspace recommended plugins, set as default formatter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
   // See http://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
-  "recommendations": ["nicoespeon.abracadabra"]
+  "recommendations": ["nicoespeon.abracadabra", "esbenp.prettier-vscode"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,5 +30,6 @@
     "statusBarItem.remoteForeground": "#e7e7e7",
     "commandCenter.border": "#e7e7e799"
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
 }


### PR DESCRIPTION
Small DX improvement.

There's precommit hook to format code with Prettier, but we can make it easier for devs to use Prettier sooner, when they write code