### PR TITLE
Fix the selection when extracting a variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Extracting a variable (`Ctrl + Alt + V` / `⌥ ⌘ V`) while selecting a portion of the value may result in a partial selection when you get to name the extracted variable. Annoying! Not anymore… The whole identifier is now selected, so you can just write the name right away 😉
+
 ## [9.4.1]
 
 ### Fixed

--- a/src/editor/adapters/vscode-editor.ts
+++ b/src/editor/adapters/vscode-editor.ts
@@ -219,6 +219,7 @@ export class VSCodeEditor implements Editor {
   }
 
   private changeEditorSelection(selection: vscode.Selection) {
+    this.editor.selection = selection;
     this.editorSelection = selection;
   }
 

--- a/src/editor/adapters/vscode-editor.ts
+++ b/src/editor/adapters/vscode-editor.ts
@@ -99,9 +99,11 @@ export class VSCodeEditor implements Editor {
     await vscode.workspace.applyEdit(edit, { isRefactoring: true });
 
     // Put cursor at correct position
-    this.editorSelection = newCursorPosition
-      ? toVSCodeCursor(newCursorPosition)
-      : cursorAtInitialStartPosition;
+    this.changeEditorSelection(
+      newCursorPosition
+        ? toVSCodeCursor(newCursorPosition)
+        : cursorAtInitialStartPosition
+    );
 
     // Scroll to correct position if it changed
     if (newCursorPosition) {
@@ -181,7 +183,7 @@ export class VSCodeEditor implements Editor {
     await vscode.workspace.applyEdit(edit);
 
     if (newCursorPosition) {
-      this.editorSelection = toVSCodeCursor(newCursorPosition);
+      this.changeEditorSelection(toVSCodeCursor(newCursorPosition));
     }
   }
 
@@ -212,8 +214,12 @@ export class VSCodeEditor implements Editor {
   }
 
   moveCursorTo(position: Position) {
-    this.editorSelection = toVSCodeCursor(position);
+    this.changeEditorSelection(toVSCodeCursor(position));
     return Promise.resolve();
+  }
+
+  private changeEditorSelection(selection: vscode.Selection) {
+    this.editorSelection = selection;
   }
 
   private get filePath(): string {


### PR DESCRIPTION
Extracting a variable (`Ctrl + Alt + V` / `⌥ ⌘ V`) while selecting a portion of the value may result in a partial selection when you get to name the extracted variable. Annoying! 

Not anymore… The whole identifier is now selected, so you can just write the name right away 😉

## Before:

https://github.com/user-attachments/assets/af28217a-f220-4d76-b905-e22e09967db1 

## After:

https://github.com/user-attachments/assets/d105b73d-e0b0-4f42-b838-ccca8633bcb0




