### PR TITLE
Don't make refactoring asynchronous as default

### DIFF
--- a/_templates/refactoring/new/refactoring.ejs.t
+++ b/_templates/refactoring/new/refactoring.ejs.t
@@ -9,7 +9,7 @@ import * as t from "../../ast";
 import { Selection } from "../../editor/selection";
 import { COMMANDS, EditorCommand, RefactoringState } from "../../refactorings";
 
-export async function <%= camelName %>(state: RefactoringState): EditorCommand {
+export function <%= camelName %>(state: RefactoringState): EditorCommand {
   const updatedCode = updateCode(t.parse(state.code), state.selection);
 
   if (!updatedCode.hasCodeChanged) {


### PR DESCRIPTION
The generator creates a function with a return value of Promise type. The expected return type of the function is EditorCommand.  A mismatch violates the [executeRefactoring function strategy](https://github.com/nicoespeon/abracadabra/blob/9e5f9044c17ad206a1312e7e78a1b8988322986a/src/refactorings.ts#L143); and the returned error message is implicit for quick correction

![I need a time to find a source of this error](https://github.com/user-attachments/assets/15ed3c30-67b7-4b83-87ce-c9bbc1396d62)  


