### PR TITLE
Fix VS Code failing to launch in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@types/pluralize": "0.0.33",
     "@types/sinon": "21.0.0",
     "@types/vscode": "1.105.0",
-    "@vscode/test-electron": "2.5.2",
+    "@vscode/test-electron": "3.1.0",
     "@vscode/vsce": "3.9.1",
     "babel-jest": "30.4.1",
     "chai": "6.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4854,16 +4854,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vscode/test-electron@npm:2.5.2":
-  version: 2.5.2
-  resolution: "@vscode/test-electron@npm:2.5.2"
+"@vscode/test-electron@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@vscode/test-electron@npm:3.1.0"
   dependencies:
     http-proxy-agent: "npm:^7.0.2"
     https-proxy-agent: "npm:^7.0.5"
     jszip: "npm:^3.10.1"
     ora: "npm:^8.1.0"
     semver: "npm:^7.6.2"
-  checksum: 10c0/30b1a30e56e14a90de9288a79e9dd71477534cda9f68dfc66f11446822c67324d8e49dbd2bfa0049a8cc9a4ddb3cafc1bae27ea6920795070fe7ae63a512ac03
+  checksum: 10c0/94dec0f45cc35ad50bdff982b377c3160de340af92e4fb5e1fe161e6ecc9bbd3718ecf33f8776da1cfb4b80930d7e9141031ee8ae264465c86c71c99923fa9e4
   languageName: node
   linkType: hard
 
@@ -5076,7 +5076,7 @@ __metadata:
     "@types/pluralize": "npm:0.0.33"
     "@types/sinon": "npm:21.0.0"
     "@types/vscode": "npm:1.105.0"
-    "@vscode/test-electron": "npm:2.5.2"
+    "@vscode/test-electron": "npm:3.1.0"
     "@vscode/vsce": "npm:3.9.1"
     babel-jest: "npm:30.4.1"
     chai: "npm:6.2.2"


### PR DESCRIPTION
Every PR's macOS CI job has been red for weeks, regardless of what the PR touches: it fails before any of our code runs, while trying to launch VS Code for the integration tests.

VS Code renamed its macOS binary a while back and removed the compatibility symlink for it on 2026-07-20. `@vscode/test-electron` 2.5.2 still looks for the old path. 3.1.0 has the fix.

Confirmed locally: VS Code now launches and the integration tests run again.